### PR TITLE
optimize/tui: TUI streaming scrollback fix + per-turn token/cost stats

### DIFF
--- a/openspec/changes/archive/2026-06-27-fix-tui-streaming-scrollback/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-27-fix-tui-streaming-scrollback/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-27

--- a/openspec/changes/archive/2026-06-27-fix-tui-streaming-scrollback/design.md
+++ b/openspec/changes/archive/2026-06-27-fix-tui-streaming-scrollback/design.md
@@ -1,0 +1,47 @@
+## Context
+
+当前 `ConversationView.renderLive()` 在每次被调用时（每个 token delta / thinking delta / tool 状态变更）都会调用 `tui.requestRender(true)`。`force=true` 会让 pi-tui 重置内部状态（`previousLines=[]`, `cursorRow=0` 等），从而强制走 `fullRender(true)` 路径，发出 `\x1b[2J\x1b[H\x1b[3J` 序列——清屏、光标归位、清除 scrollback。
+
+这导致终端 scrollback 缓冲区在流式输出期间被持续破坏，用户永远无法向上滚动查看历史内容。
+
+pi-tui 的 `requestRender(false)`（force=false）路径使用差分渲染：比较新旧渲染行，只更新变化的部分。它支持行追加（`appendStart` 路径）、行内容修改（`firstChanged`/`lastChanged` 路径）、行缩减（`clearOnShrink` 路径）。所有这些路径都不发送 `\x1b[3J`。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 流式输出期间终端 scrollback 完整保留
+- 用户可以用鼠标滚轮或 Shift+PgUp 正常翻阅历史
+- 流式输出的视觉效果不受影响（无闪烁、无跳帧）
+
+**Non-Goals:**
+- 不实现 TUI 内自定义滚动 UI（如 vim 式的滚动窗口）
+- 不改变 pi-tui 框架代码
+- 不修改 `render()`（已完成 blocks 的渲染方式保持不变）
+
+## Decisions
+
+### Decision 1: 只改 `renderLive()` 的 force 参数
+
+`renderLive()` 调用 `tui.requestRender(true)` → `tui.requestRender(false)`。
+
+**Why not modify pi-tui framework:** pi-tui 的 `fullRender` 中 `\x1b[3J` 在终端 resize、初次渲染等场景下是正确的行为。只在流式渲染中抑制即可，不需要改动框架。
+
+**Why not add a parameter to requestRender:** 增加 `clearScrollback` 参数需要改框架 API，影响范围大。
+
+**Why not wrap renderLive in debounce/throttle:** pi-tui 自带的 `MIN_RENDER_INTERVAL_MS=16` 和 requestRender 的 schedule 机制已经做了帧率管控。额外节流不会改善 scrollback 问题（根因是 `\x1b[3J` 而非渲染频率）。
+
+### Decision 2: 保持 `render()` 的 `force=true` 不变
+
+`ConversationView.render()` 处理已确定的 block 追加（用户消息、助手完成消息、info/error 等），走全量渲染路径是合理的：block 是单次追加的，不是高频连续的，`force=true` 提供确定性清屏行为。此处不需要改动。
+
+## Risks / Trade-offs
+
+- **[Risk] 差分渲染在快速内容变化时可能出现视觉残留** → `renderLive()` 在每次调用前会先 remove 所有 live 子组件再重建，这确保 Box 的子组件列表与预期一致。pi-tui 的差分比较基于渲染后的行文本，与子组件列表无关。若出现残留，可通过增加 `force=true` 的兜底触发来修复。
+
+- **[Risk] `currentAssistantText` 内容缩短（如编辑撤回）导致行数缩减** → pi-tui 有 `clearOnShrink` 路径，默认开启（`PI_CLEAR_ON_SHRINK=1` 默认为 falsy，但 `clearOnShrink` 属性默认为 `false`... 需要验证）。如果内容缩减且不清屏，旧行可能残留。`thinkingBuffer` 和 `currentAssistantText` 都是 monotonic 增长的（只在 `startAssistantMessage()` 时重置），不会出现中途缩减的情况。Tool 的 `renderedToolCount` 也是 monotonic。
+
+- **[Risk] 内容行数增长导致 terminal 自动 scroll 出用户当前视口** → 这是终端模拟器的默认行为：向底部追加内容时，如果用户在 scrollback 中，终端会停留在用户位置（不 auto-scroll）。如果用户在底部（实时视图），终端的 auto-scroll 会让用户跟随新内容。这正是期望的行为。
+
+## Open Questions
+
+- `PI_CLEAR_ON_SHRINK` 的默认行为需要确认。如果内容缩减时不清屏，`renderLive()` 在 `startAssistantMessage()` 重置后可能出现残留。建议在 `startAssistantMessage()` 中额外调用一次 `requestRender(true)` 作为状态边界清理。

--- a/openspec/changes/archive/2026-06-27-fix-tui-streaming-scrollback/proposal.md
+++ b/openspec/changes/archive/2026-06-27-fix-tui-streaming-scrollback/proposal.md
@@ -1,0 +1,22 @@
+## Why
+
+TUI 中 LLM 流式输出时，每个 token delta 都触发 `renderLive()` → `tui.requestRender(true)` → `fullRender(true)`，后者发出 `\x1b[3J`（Erase Scrollback），导致终端 scrollback 缓冲区被持续清空。用户无法向上滚动浏览历史内容，只能被动卡在最底部。
+
+## What Changes
+
+- `ConversationView.renderLive()` 将 `tui.requestRender(true)` 改为 `tui.requestRender(false)`，走差分渲染路径，不再触发 scrollback 清除
+- 流式输出期间，终端 scrollback 完整保留，用户可自由向上滚动（鼠标滚轮 / Shift+PgUp）
+- 已完成的 blocks 不受影响（`render()` 始终走 `requestRender(true)`，确保确定性全量渲染）
+
+## Capabilities
+
+### New Capabilities
+- `tui-streaming-scrollback`: 流式输出期间终端 scrollback 不被清空，用户可自由翻阅历史
+
+### Modified Capabilities
+<!-- None — 纯 bug 修复，不改变任何 spec 级需求 -->
+
+## Impact
+
+- `src/ui/conversation.ts` — `renderLive()` 方法，`line 606`: `this.tui.requestRender(true)` → `this.tui.requestRender(false)`
+- 依赖 pi-tui 差分渲染的正确性（`appendStart`、`firstChanged`/`lastChanged` 路径处理内容增长的行变更）

--- a/openspec/changes/archive/2026-06-27-fix-tui-streaming-scrollback/specs/tui-streaming-scrollback/spec.md
+++ b/openspec/changes/archive/2026-06-27-fix-tui-streaming-scrollback/specs/tui-streaming-scrollback/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+
+### Requirement: Streaming render SHALL preserve terminal scrollback
+
+`ConversationView.renderLive()` SHALL call `tui.requestRender(false)` instead of `tui.requestRender(true)` so that the terminal scrollback buffer is never cleared by `\x1b[3J` during LLM streaming output.
+
+#### Scenario: User scrolls up during streaming
+
+- **WHEN** LLM is streaming output (token deltas arriving) AND the user scrolls up in the terminal (mouse wheel or Shift+PgUp)
+- **THEN** the user's viewport SHALL remain at the scrolled position, and previously output content SHALL be visible in the terminal scrollback
+
+#### Scenario: Content continues to stream while user is scrolled up
+
+- **WHEN** the user has scrolled up during streaming AND a new token delta arrives
+- **THEN** the new content SHALL be appended at the bottom of the output without disrupting the user's scroll position or clearing scrollback
+
+#### Scenario: Finalized blocks render with force
+
+- **WHEN** `ConversationView.render()` is called for finalized blocks
+- **THEN** it SHALL continue to call `tui.requestRender(true)` to ensure deterministic full-screen rendering for committed content
+
+#### Scenario: Streaming content changes within same line count
+
+- **WHEN** `renderLive()` produces rendered output with the same number of lines as the previous call but changed content
+- **THEN** pi-tui differential rendering SHALL detect the changed lines via `firstChanged`/`lastChanged` and rewrite only those lines
+
+#### Scenario: Streaming content grows in line count
+
+- **WHEN** `renderLive()` produces rendered output with more lines than the previous call
+- **THEN** pi-tui differential rendering SHALL detect `appendedLines=true`, scroll content to make room, and append new lines via `appendStart` path

--- a/openspec/changes/archive/2026-06-27-fix-tui-streaming-scrollback/tasks.md
+++ b/openspec/changes/archive/2026-06-27-fix-tui-streaming-scrollback/tasks.md
@@ -1,0 +1,13 @@
+## 1. Core Fix
+
+- [x] 1.1 将 `ConversationView.renderLive()` 中 `this.tui.requestRender(true)` 改为 `this.tui.requestRender(false)`
+
+## 2. Boundary Safety
+
+- [x] 2.1 在 `startAssistantMessage()` 中，重置 live 状态后调用一次 `this.tui.requestRender(true)` 作为状态边界清理，确保新一轮流式输出的差分基准正确
+
+## 3. Verification
+
+- [ ] 3.1 手动测试：启动 TUI、触发 LLM 对话，在流式输出期间用鼠标/Shift+PgUp 向上滚动，验证 scrollback 完整可翻阅
+- [ ] 3.2 手动测试：确认流式输出视觉效果无闪烁、`thinking` buffer 和 tool 状态显示正常
+- [ ] 3.3 手动测试：多轮对话后，非流式内容（用户消息、完成消息、info/error）渲染正常

--- a/openspec/changes/archive/2026-06-27-tui-token-stats/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-27-tui-token-stats/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-27

--- a/openspec/changes/archive/2026-06-27-tui-token-stats/design.md
+++ b/openspec/changes/archive/2026-06-27-tui-token-stats/design.md
@@ -1,0 +1,75 @@
+## Context
+
+当前 `turn:end` 事件的 `usage` 字段是简化结构 `{inputTokens, outputTokens}`，而 `AssistantMessage.usage` 是完整的 pi-ai `Usage` 类型（含 input, output, cacheRead, cacheWrite, totalTokens, cost）。TUI 的 `finishAssistantMessage()` 在渲染后会追加 `⏱ total wait` dim 行——token/cost/上下文占比信息天然适合追加到同一行。
+
+## Goals / Non-Goals
+
+**Goals:**
+- TUI 每轮推理结束后，在一行 dim 文本中展示 token 消耗（输入/输出）、API 成本、上下文窗口占用百分比
+- 扩展 `turn:end` 事件 payload 使其携带完整 cost 信息
+- 与现有 `⏱ total wait` 合并为一行，格式紧凑不喧宾夺主
+- 上下文占比用 `▓▓ XX%` 方块展示，按阈值变色（≤80% dim，>80% yellow，>95% red）
+
+**Non-Goals:**
+- 不在 web 前端显示（web 有自己的 token 统计面板）
+- 不做 session 级别的累计统计
+- 不缓存历史 usage——只在该轮 `finishAssistantMessage()` 时输出一次
+- 不做精确上下文 token 统计（使用 `estimateMessagesTokens` 估算，误差可接受）
+
+## Decisions
+
+### 1. 扩展 turn:end usage 而非新增事件
+
+**选择**：扩展 `turn:end` 的 `usage` 字段为完整结构（含 cacheRead, cacheWrite, total, cost.total）
+
+**备选**：新增独立的 `turn:usage` 事件
+
+**理由**：usage 信息与 turn 结束是同一时序，拆分为两个事件会增加 handler 重数且无实际解耦收益。下游 TUI handler 只需在同一个回调里拿到全部信息。
+
+### 2. 事件 payload 用扁平结构，不直接引入 pi-ai Usage 类型
+
+**选择**：`{ input: number; output: number; cacheRead: number; cacheWrite: number; total: number; cost: { total: number } }`
+
+**理由**：事件层应是框架自有类型，不应依赖 pi-ai 的内部类型。只取 TUI 展示需要的字段，cost 只带 `total`，不引入 `cost.input/output/cacheRead/cacheWrite` 四个细分字段。
+
+### 3. 显示格式
+
+**选择**：`⏱ 3.2s · 📊 12.4k↓ 3.2k↑ · ▓▓ 77% · 💰 $0.0032`
+
+格式化规则：
+- token：>= 1M → `1.2M`，>= 1000 → `12.4k`，否则原值
+- cost：>= $0.01 → `$0.03`，否则 → `¢0.3`
+- 各部分用 ` · ` 分隔
+- 缺少某部分则省略（如无 wait time 则只显示 token、context 和 cost）
+- `▓▓` 方块后跟百分比整数（四舍五入），≤80% dim 色，>80% yellow，>95% red
+
+**备选**：分三行展示 → 占用过多垂直空间，不符合 TUI 紧凑风格
+
+### 4. 格式化函数位置
+
+**选择**：放在 `src/ui/tui-app.ts` 作为私有 helper 函数（模块级，非类方法）
+
+**理由**：仅 TUI 使用，不需要跨模块复用。模块级函数便于测试且不污染类型接口。
+
+### 5. 上下文占比数据来源
+
+**选择**：`ContextManager.getEstimatedTokens(messages)` / `ContextManager.getContextWindow()`
+
+**理由**：不依赖事件层新字段，`ContextManager` 已在 `TuiApp.deps` 中直接可访问。`getEstimatedTokens()` 基于字符数快速估算（~4 chars/token），在 dim 提示行场景精确度足够，无需精确 tokenizer。
+
+### 6. 上下文百分比阈值配色
+
+**选择**：≤80% dim（正常融入），>80% yellow（注意），>95% red（危险）
+
+**理由**：直观的交通灯模式。80% 是自然注意力阈值，95% 以上需要立即行动（compact 或换模型）。颜色通过 `c.yellow()` / `c.red()` 应用，与 TUI 现有配色体系一致。
+
+## Risks / Trade-offs
+
+- **[cost 可能为 0]**：某些 provider 不返回 cost 数据时，`💰` 段会被省略。→ 静默降级，无异常。
+- **[cache 数据可能不准确]**：部分 provider 的 cache 统计不稳定。→ 当前只传入 payload 但 TUI 首版不展示 cache，预留后续扩展。
+- **[Web 端不受影响]**：web-backend 的 `turn:end` handler 不读取 usage，无破坏性。
+- **[上下文估算有误差]**：`estimateMessagesTokens` 基于 ~4 chars/token 估算，可能偏离实际 ±15%。→ dim 提示行场景可接受，不做精确计数承诺。
+
+## Open Questions
+
+- 是否需要后续加 `/tokens` 命令展示 session 累计？→ 暂不纳入本 change

--- a/openspec/changes/archive/2026-06-27-tui-token-stats/proposal.md
+++ b/openspec/changes/archive/2026-06-27-tui-token-stats/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+TUI 用户每次推理结束后看不到 token 消耗和成本，无法判断单轮开销，也无法感知上下文窗口剩余容量。`turn:end` 事件已经携带完整 `Usage` 数据，`finishAssistantMessage()` 也已追加 `⏱ total wait`，只需在同一行追加 token/cost 和上下文占比即可零成本实现。
+
+## What Changes
+
+- 扩展 `turn:end` 事件的 `usage` 字段，从 `{inputTokens, outputTokens}` 升级为完整 Usage（含 cacheRead, cacheWrite, total, cost.total）
+- TUI `finishAssistantMessage()` 在 `⏱ total wait` 同行追加 `📊 12.4k↓ 3.2k↑ · ▓▓ 77% · 💰 $0.0012`
+- token 格式化：≥1000 用 `k`，≥1M 用 `M`；cost < $0.01 用美分 `¢`
+- 上下文占比通过 `ContextManager.getEstimatedTokens()` / `getContextWindow()` 计算，无需改事件层
+- 百分比 ≥80% 黄色告警，≥95% 红色告警
+
+## Capabilities
+
+### New Capabilities
+
+- `tui-token-stats`: TUI 推理结束后显示 token 消耗、API 成本统计、上下文窗口占用百分比
+
+### Modified Capabilities
+
+- `harness-event-bus`: `turn:end` 的 `usage` 字段从简化结构升级为包含 cache 和 cost 的完整结构
+
+## Impact
+
+- `src/core/events.ts` — `HarnessEvent` 联合类型中 `turn:end` 的 usage 字段扩展
+- `src/core/harness.ts` — 映射 `AssistantMessage.usage` 到事件 payload
+- `src/ui/tui-backend.ts` — 订阅 handler 传递 usage 到 `finishAssistantMessage()`
+- `src/ui/tui-app.ts` — `finishAssistantMessage()` 签名和实现（新增上下文占比计算和颜色告警）
+- `src/ui/conversation.ts` — 无改动（通过 `addInfo` 追加 dim 行）
+- `src/context/manager.ts` — 无改动（复用现有 `getEstimatedTokens()` / `getContextWindow()`）

--- a/openspec/changes/archive/2026-06-27-tui-token-stats/specs/harness-event-bus/spec.md
+++ b/openspec/changes/archive/2026-06-27-tui-token-stats/specs/harness-event-bus/spec.md
@@ -1,0 +1,27 @@
+## MODIFIED Requirements
+
+### Requirement: HarnessEvent complete event catalog
+
+The `HarnessEvent` discriminated union SHALL include all event types in the catalog: LLM streaming (`llm:thinking:delta`, `llm:text:delta`, `llm:retry`, `llm:usage`), Tool (`tool:start`, `tool:end`), Turn lifecycle (`turn:start`, `turn:streaming:start`, `turn:streaming:end`, `turn:end`, `turn:abort`, `turn:error`), Processing (`processing:start`, `processing:stop`), Session (`session:created`, `session:loaded`, `session:saved`, `session:deleted`), UI (`message:user`, `ui:info`, `ui:error`, `ui:warning`, `ui:image:pending`, `ui:conversation:clear`, `ui:focus:editor`), Config (`config:change`), and MCP (`mcp:state`, `mcp:browser:open`, `mcp:app:registered`).
+
+#### Scenario: Discriminated union type-checking
+
+- **WHEN** a handler is registered for `"tool:start"`
+- **THEN** TypeScript SHALL infer the handler parameter type as `{ type: "tool:start"; name: string; args: unknown }`
+- **AND** SHALL reject access to properties from other event types (e.g., `delta`)
+
+#### Scenario: Every event has a unique type string
+
+- **WHEN** the `HarnessEvent` type is inspected
+- **THEN** no two union members SHALL have the same `type` literal value
+
+#### Scenario: turn:end usage carries full token and cost data
+
+- **WHEN** the `turn:end` event is emitted
+- **THEN** its `usage` field SHALL be of type `{ input: number; output: number; cacheRead: number; cacheWrite: number; total: number; cost: { total: number } } | undefined`
+- **AND** the `usage.input` field SHALL contain input token count
+- **AND** the `usage.output` field SHALL contain output token count
+- **AND** the `usage.cacheRead` field SHALL contain cache read token count
+- **AND** the `usage.cacheWrite` field SHALL contain cache write token count
+- **AND** the `usage.total` field SHALL contain total token count
+- **AND** the `usage.cost.total` field SHALL contain the API cost in USD

--- a/openspec/changes/archive/2026-06-27-tui-token-stats/specs/tui-token-stats/spec.md
+++ b/openspec/changes/archive/2026-06-27-tui-token-stats/specs/tui-token-stats/spec.md
@@ -1,0 +1,90 @@
+## ADDED Requirements
+
+### Requirement: TUI displays token usage after each turn
+
+The TUI SHALL display token consumption, API cost, and context window utilization percentage after each assistant turn completes. The information SHALL appear as a dimmed single line appended after the assistant message, merged with the existing `⏱ total wait` line when both are present.
+
+#### Scenario: Full display with wait time, token usage, and cost
+
+- **WHEN** an assistant turn completes with total wait time >= 1 second AND usage data containing input tokens, output tokens, and cost.total > 0, AND context window utilization is available
+- **THEN** the TUI SHALL render a dim line in the format `⏱ 3.2s · 📊 12.4k↓ 3.2k↑ · ▓▓ 77% · 💰 $0.0032`
+
+#### Scenario: Token and cost without wait time
+
+- **WHEN** an assistant turn completes with total wait time < 1 second AND usage data is present
+- **THEN** the TUI SHALL render a dim line in the format `📊 12.4k↓ 3.2k↑ · ▓▓ 77% · 💰 $0.0032`
+- **AND** the `⏱` segment SHALL be omitted
+
+#### Scenario: Token usage without cost
+
+- **WHEN** an assistant turn completes and cost.total is 0 or undefined
+- **THEN** the TUI SHALL render a dim line in the format `📊 12.4k↓ 3.2k↑ · ▓▓ 77%`
+- **AND** the `💰` segment SHALL be omitted
+
+#### Scenario: No usage data available
+
+- **WHEN** an assistant turn completes but `turn:end` event carries no usage payload
+- **THEN** the TUI SHALL render only the existing `⏱ total wait` line (if applicable)
+- **AND** no token/cost information SHALL be displayed
+
+### Requirement: Token formatting
+
+The system SHALL format token counts using human-readable abbreviations.
+
+#### Scenario: Format tokens >= 1 million
+
+- **WHEN** a token count is 1,500,000
+- **THEN** it SHALL be formatted as `1.5M`
+
+#### Scenario: Format tokens >= 1000
+
+- **WHEN** a token count is 12,400
+- **THEN** it SHALL be formatted as `12.4k`
+
+#### Scenario: Format tokens < 1000
+
+- **WHEN** a token count is 542
+- **THEN** it SHALL be formatted as `542`
+
+### Requirement: Cost formatting
+
+The system SHALL format API cost using dollar or cent notation based on magnitude.
+
+#### Scenario: Format cost >= $0.01
+
+- **WHEN** cost.total is 0.0324
+- **THEN** it SHALL be formatted as `$0.0324`
+
+#### Scenario: Format cost < $0.01
+
+- **WHEN** cost.total is 0.0012
+- **THEN** it SHALL be formatted as `¢0.12`
+
+#### Scenario: Format zero cost
+
+- **WHEN** cost.total is 0
+- **THEN** the cost segment SHALL be omitted entirely
+
+### Requirement: Context window utilization display
+
+The system SHALL display the percentage of the model's context window currently occupied by the conversation. The percentage SHALL be computed as `Math.round(estimatedTokens / contextWindow * 100)` and displayed with the `▓▓` prefix. Color SHALL vary by threshold.
+
+#### Scenario: Normal utilization (≤80%)
+
+- **WHEN** context utilization is ≤80%
+- **THEN** the `▓▓ XX%` segment SHALL be rendered in dim color
+
+#### Scenario: High utilization (>80%)
+
+- **WHEN** context utilization is >80% and ≤95%
+- **THEN** the `▓▓ XX%` segment SHALL be rendered in yellow
+
+#### Scenario: Critical utilization (>95%)
+
+- **WHEN** context utilization is >95%
+- **THEN** the `▓▓ XX%` segment SHALL be rendered in red
+
+#### Scenario: Context window unavailable
+
+- **WHEN** the `ContextManager` cannot provide a valid context window size
+- **THEN** the `▓▓` segment SHALL be omitted

--- a/openspec/changes/archive/2026-06-27-tui-token-stats/tasks.md
+++ b/openspec/changes/archive/2026-06-27-tui-token-stats/tasks.md
@@ -1,0 +1,26 @@
+## 1. Event Layer
+
+- [x] 1.1 Expand `turn:end` usage type in `src/core/events.ts`: change from `{ inputTokens: number; outputTokens: number }` to `{ input: number; output: number; cacheRead: number; cacheWrite: number; total: number; cost: { total: number } }`
+- [x] 1.2 Update `src/core/harness.ts` to map full `AssistantMessage.usage` to the new usage payload structure in the `turn:end` emit call
+
+## 2. TUI Rendering
+
+- [x] 2.1 Add `formatTokens()` and `formatCost()` helper functions in `src/ui/tui-app.ts` (module-level, private)
+- [x] 2.2 Update `finishAssistantMessage()` signature in `src/ui/tui-app.ts` to accept `usage?: { input: number; output: number; cacheRead: number; cacheWrite: number; total: number; cost: { total: number } }`
+- [x] 2.3 Implement the merged-line rendering logic: combine `⏱ total wait` (if present) with `📊 tokens↓↑`, `▓▓ context%`, and `💰 cost` into a single dim `addInfo` call
+- [x] 2.4 Update `src/ui/tui-backend.ts` to pass `e.usage` from the `turn:end` event handler to `this.tui.finishAssistantMessage(e.usage)`
+
+## 3. Context Percentage
+
+- [x] 3.1 Add `formatContextPercent(estimated: number, contextWindow: number)` helper function in `src/ui/tui-app.ts`: compute `Math.round(estimated / contextWindow * 100)`, return dim/yellow/red colored `▓▓ XX%` string based on threshold (≤80% dim, >80% yellow, >95% red)
+- [x] 3.2 Update `finishAssistantMessage()` to fetch `estimatedTokens` from `this.deps.contextManager.getEstimatedTokens(this.deps.agent.state.messages)` and `contextWindow` from `this.deps.contextManager.getContextWindow()`, append `▓▓ XX%` segment to `parts[]`
+- [x] 3.3 Handle edge case: when `contextWindow` is 0 or `estimatedTokens` is NaN, silently omit the `▓▓` segment
+
+## 4. Verify
+
+- [x] 4.1 Run `npm run typecheck` to ensure all type changes compile
+- [x] 4.2 Run `npm test` to verify no regressions
+- [x] 4.3 Run `npm run typecheck` after context percentage changes
+- [x] 4.4 Run `npm test` after context percentage changes
+- [x] 4.5 Manual smoke test: start TUI (`npm start`), send a message, verify token/cost line appears after assistant response
+- [ ] 4.6 Manual smoke test: verify `▓▓ XX%` appears with correct color at various utilization levels

--- a/openspec/specs/harness-event-bus/spec.md
+++ b/openspec/specs/harness-event-bus/spec.md
@@ -53,6 +53,17 @@ The `HarnessEvent` discriminated union SHALL include all event types in the cata
 - **WHEN** the `HarnessEvent` type is inspected
 - **THEN** no two union members SHALL have the same `type` literal value
 
+#### Scenario: turn:end usage carries full token and cost data
+
+- **WHEN** the `turn:end` event is emitted
+- **THEN** its `usage` field SHALL be of type `{ input: number; output: number; cacheRead: number; cacheWrite: number; total: number; cost: { total: number } } | undefined`
+- **AND** the `usage.input` field SHALL contain input token count
+- **AND** the `usage.output` field SHALL contain output token count
+- **AND** the `usage.cacheRead` field SHALL contain cache read token count
+- **AND** the `usage.cacheWrite` field SHALL contain cache write token count
+- **AND** the `usage.total` field SHALL contain total token count
+- **AND** the `usage.cost.total` field SHALL contain the API cost in USD
+
 ### Requirement: turn:abort carries reason field
 
 The `turn:abort` event SHALL include a `reason` field with value `"user"` or `"system"`. `"user"` indicates the user explicitly triggered abort (e.g., Esc key, abort button). `"system"` indicates a system-initiated abort (e.g., shutdown, timeout, session switch).

--- a/openspec/specs/tui-streaming-scrollback/spec.md
+++ b/openspec/specs/tui-streaming-scrollback/spec.md
@@ -1,0 +1,34 @@
+## Purpose
+
+Preserve terminal scrollback buffer during LLM streaming output by using differential rendering instead of full-screen clears.
+
+## Requirements
+
+### Requirement: Streaming render SHALL preserve terminal scrollback
+
+`ConversationView.renderLive()` SHALL call `tui.requestRender(false)` instead of `tui.requestRender(true)` so that the terminal scrollback buffer is never cleared by `\x1b[3J` during LLM streaming output.
+
+#### Scenario: User scrolls up during streaming
+
+- **WHEN** LLM is streaming output (token deltas arriving) AND the user scrolls up in the terminal (mouse wheel or Shift+PgUp)
+- **THEN** the user's viewport SHALL remain at the scrolled position, and previously output content SHALL be visible in the terminal scrollback
+
+#### Scenario: Content continues to stream while user is scrolled up
+
+- **WHEN** the user has scrolled up during streaming AND a new token delta arrives
+- **THEN** the new content SHALL be appended at the bottom of the output without disrupting the user's scroll position or clearing scrollback
+
+#### Scenario: Finalized blocks render with force
+
+- **WHEN** `ConversationView.render()` is called for finalized blocks
+- **THEN** it SHALL continue to call `tui.requestRender(true)` to ensure deterministic full-screen rendering for committed content
+
+#### Scenario: Streaming content changes within same line count
+
+- **WHEN** `renderLive()` produces rendered output with the same number of lines as the previous call but changed content
+- **THEN** pi-tui differential rendering SHALL detect the changed lines via `firstChanged`/`lastChanged` and rewrite only those lines
+
+#### Scenario: Streaming content grows in line count
+
+- **WHEN** `renderLive()` produces rendered output with more lines than the previous call
+- **THEN** pi-tui differential rendering SHALL detect `appendedLines=true`, scroll content to make room, and append new lines via `appendStart` path

--- a/openspec/specs/tui-token-stats/spec.md
+++ b/openspec/specs/tui-token-stats/spec.md
@@ -1,0 +1,94 @@
+## Purpose
+
+TUI display of token consumption, API cost, and context window utilization after each assistant turn.
+
+## Requirements
+
+### Requirement: TUI displays token usage after each turn
+
+The TUI SHALL display token consumption, API cost, and context window utilization percentage after each assistant turn completes. The information SHALL appear as a dimmed single line appended after the assistant message, merged with the existing `⏱ total wait` line when both are present.
+
+#### Scenario: Full display with wait time, token usage, and cost
+
+- **WHEN** an assistant turn completes with total wait time >= 1 second AND usage data containing input tokens, output tokens, and cost.total > 0, AND context window utilization is available
+- **THEN** the TUI SHALL render a dim line in the format `⏱ 3.2s · 📊 12.4k↓ 3.2k↑ · ▓▓ 77% · 💰 $0.0032`
+
+#### Scenario: Token and cost without wait time
+
+- **WHEN** an assistant turn completes with total wait time < 1 second AND usage data is present
+- **THEN** the TUI SHALL render a dim line in the format `📊 12.4k↓ 3.2k↑ · ▓▓ 77% · 💰 $0.0032`
+- **AND** the `⏱` segment SHALL be omitted
+
+#### Scenario: Token usage without cost
+
+- **WHEN** an assistant turn completes and cost.total is 0 or undefined
+- **THEN** the TUI SHALL render a dim line in the format `📊 12.4k↓ 3.2k↑ · ▓▓ 77%`
+- **AND** the `💰` segment SHALL be omitted
+
+#### Scenario: No usage data available
+
+- **WHEN** an assistant turn completes but `turn:end` event carries no usage payload
+- **THEN** the TUI SHALL render only the existing `⏱ total wait` line (if applicable)
+- **AND** no token/cost information SHALL be displayed
+
+### Requirement: Token formatting
+
+The system SHALL format token counts using human-readable abbreviations.
+
+#### Scenario: Format tokens >= 1 million
+
+- **WHEN** a token count is 1,500,000
+- **THEN** it SHALL be formatted as `1.5M`
+
+#### Scenario: Format tokens >= 1000
+
+- **WHEN** a token count is 12,400
+- **THEN** it SHALL be formatted as `12.4k`
+
+#### Scenario: Format tokens < 1000
+
+- **WHEN** a token count is 542
+- **THEN** it SHALL be formatted as `542`
+
+### Requirement: Cost formatting
+
+The system SHALL format API cost using dollar or cent notation based on magnitude.
+
+#### Scenario: Format cost >= $0.01
+
+- **WHEN** cost.total is 0.0324
+- **THEN** it SHALL be formatted as `$0.0324`
+
+#### Scenario: Format cost < $0.01
+
+- **WHEN** cost.total is 0.0012
+- **THEN** it SHALL be formatted as `¢0.12`
+
+#### Scenario: Format zero cost
+
+- **WHEN** cost.total is 0
+- **THEN** the cost segment SHALL be omitted entirely
+
+### Requirement: Context window utilization display
+
+The system SHALL display the percentage of the model's context window currently occupied by the conversation. The percentage SHALL be computed as `Math.round(estimatedTokens / contextWindow * 100)` and displayed with the `▓▓` prefix. Color SHALL vary by threshold.
+
+#### Scenario: Normal utilization (≤80%)
+
+- **WHEN** context utilization is ≤80%
+- **THEN** the `▓▓ XX%` segment SHALL be rendered in dim color
+
+#### Scenario: High utilization (>80%)
+
+- **WHEN** context utilization is >80% and ≤95%
+- **THEN** the `▓▓ XX%` segment SHALL be rendered in yellow
+
+#### Scenario: Critical utilization (>95%)
+
+- **WHEN** context utilization is >95%
+- **THEN** the `▓▓ XX%` segment SHALL be rendered in red
+
+#### Scenario: Context window unavailable
+
+- **WHEN** the `ContextManager` cannot provide a valid context window size
+- **THEN** the `▓▓` segment SHALL be omitted

--- a/src/core/events.ts
+++ b/src/core/events.ts
@@ -20,7 +20,7 @@ export type HarnessEvent =
   // Turn lifecycle
   | { type: "turn:start" }
   | { type: "turn:streaming:start" }
-  | { type: "turn:end"; stopReason?: string; usage?: { inputTokens: number; outputTokens: number } }
+  | { type: "turn:end"; stopReason?: string; usage?: { input: number; output: number; cacheRead: number; cacheWrite: number; total: number; cost: { total: number } } }
   | { type: "turn:abort"; reason: "user" | "system" }
   | { type: "turn:error"; error: string; attempt?: number; maxRetries?: number }
 

--- a/src/core/harness.ts
+++ b/src/core/harness.ts
@@ -1108,7 +1108,8 @@ You have a \`skill\` tool available. When you decide to use a skill from the lis
           // Save session before broadcasting so sidebar gets fresh metadata
           this.sessionManager.trySaveSession(this.agent);
           const turnEndMsg = event.message as AssistantMessage;
-          this.events.emit({ type: "turn:end", stopReason: turnEndMsg?.stopReason, usage: turnEndMsg?.usage as any });
+          const rawUsage = turnEndMsg?.usage;
+          this.events.emit({ type: "turn:end", stopReason: turnEndMsg?.stopReason, usage: rawUsage ? { input: rawUsage.input, output: rawUsage.output, cacheRead: rawUsage.cacheRead, cacheWrite: rawUsage.cacheWrite, total: rawUsage.totalTokens, cost: { total: rawUsage.cost.total } } : undefined });
           const msg = turnEndMsg;
           if (msg?.stopReason === "length") {
             this.events.emit({ type: "ui:info", text: "Output truncated (hit max_tokens). Continue from where you left off." });

--- a/src/ui/conversation.ts
+++ b/src/ui/conversation.ts
@@ -191,6 +191,7 @@ export class ConversationView {
     this.thinkingBuffer = "";
     this.toolEntries = [];
     this.renderedToolCount = 0;
+    this.tui.requestRender(true);
   }
 
   thinkingDelta(delta: string): void {
@@ -603,6 +604,6 @@ export class ConversationView {
       this.liveComponents.push(permText);
     }
 
-    this.tui.requestRender(true);
+    this.tui.requestRender(false);
   }
 }

--- a/src/ui/tui-app.ts
+++ b/src/ui/tui-app.ts
@@ -53,6 +53,7 @@ class HybridAutocompleteProvider implements AutocompleteProvider {
   constructor(slashCommands: { name: string; description?: string }[], projectPath: string) {
     this.projectPath = projectPath;
     this.slashProvider = new CombinedAutocompleteProvider(slashCommands, projectPath, null);
+
   }
 
   async getSuggestions(
@@ -108,6 +109,25 @@ class HybridAutocompleteProvider implements AutocompleteProvider {
   }
 }
 
+function formatTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return String(n);
+}
+
+function formatContextPercent(estimated: number, contextWindow: number): string | null {
+  if (contextWindow <= 0 || !isFinite(estimated) || Number.isNaN(estimated)) return null;
+  const pct = Math.round((estimated / contextWindow) * 100);
+  const text = `▓▓ ${pct}%`;
+  if (pct > 95) return c.red(text);
+  if (pct > 80) return c.yellow(text);
+  return c.dim(text);
+}
+
+function formatCost(total: number): string {
+  if (total >= 0.01) return `$${total.toFixed(4)}`;
+  return `¢${(total * 100).toFixed(2)}`;
+}
 
 export class TuiApp {
   private deps: HarnessAPI;
@@ -842,7 +862,6 @@ export class TuiApp {
     });
   }
 
-
   private handleCtrlC(): void {
     if (this.resolvePermission) {
       this.resolvePermissionChoice({ decision: "deny" });
@@ -896,13 +915,27 @@ export class TuiApp {
     this.conversation.toolEnd(name, result, isError);
   }
 
-  finishAssistantMessage(): void {
+  finishAssistantMessage(usage?: { input: number; output: number; cacheRead: number; cacheWrite: number; total: number; cost: { total: number } }): void {
     this.finalizeIdleSegment();
     this.conversation.finishAssistantMessage();
+    const parts: string[] = [];
     if (this.totalWaitMs >= 1000) {
-      this.conversation.addInfo(
-        c.dim(`⏱ total wait: ${this.formatElapsed(this.totalWaitMs)} (${this.waitSegments.length} segment${this.waitSegments.length > 1 ? "s" : ""})`),
-      );
+      parts.push(`⏱ ${this.formatElapsed(this.totalWaitMs)}`);
+    }
+    if (usage && usage.input > 0 && usage.output > 0) {
+      parts.push(`📊 ${formatTokens(usage.input)}↓ ${formatTokens(usage.output)}↑`);
+    }
+    {
+      const estimatedTokens = this.deps.contextManager.getEstimatedTokens(this.deps.agent.state.messages);
+      const contextWindow = this.deps.contextManager.getContextWindow();
+      const ctxStr = formatContextPercent(estimatedTokens, contextWindow);
+      if (ctxStr) parts.push(ctxStr);
+    }
+    if (usage && usage.cost.total > 0) {
+      parts.push(`💰 ${formatCost(usage.cost.total)}`);
+    }
+    if (parts.length > 0) {
+      this.conversation.addInfo(c.dim(parts.join(" · ")));
     }
   }
 
@@ -1190,7 +1223,6 @@ export class TuiApp {
     this.focusEditor();
     this.tui.requestRender(true);
   }
-
 
   replayMessages(messages: unknown[]): void {
     this.conversation.replayMessages(messages);

--- a/src/ui/tui-backend.ts
+++ b/src/ui/tui-backend.ts
@@ -20,7 +20,7 @@ export class TuiBackend implements UiBackend {
     deps.events.on("tool:start", (e) => { this.tui.toolStart(e.name, e.args); });
     deps.events.on("tool:end", (e) => { this.tui.toolEnd(e.name, e.result, e.isError); });
     deps.events.on("turn:streaming:start", () => { this.tui.startAssistantMessage(); });
-    deps.events.on("turn:end", () => { this.tui.finishAssistantMessage(); });
+    deps.events.on("turn:end", (e) => { this.tui.finishAssistantMessage(e.usage); });
     deps.events.on("message:user", (e) => { this.tui.addUserMessage(e.text); });
     deps.events.on("ui:info", (e) => { this.tui.addInfo(e.text, e.display); });
     deps.events.on("ui:error", (e) => { this.tui.addError(e.text); });


### PR DESCRIPTION
## Summary

   两处 TUI 体验优化：

   ### 1. 流式输出期间保留 scrollback（`fix-tui-streaming-scrollback`）

   - `renderLive()` 从 `requestRender(true)` 改为 `requestRender(false)`，不再用
   `\x1b[3J` 清空 scrollback buffer
   - `startAssistantMessage()` 中新增一次 `requestRender(true)`
   作为状态边界清理，确保新一轮差分基准正确
   - 用户可以在 LLM 流式输出期间自由翻阅历史内容

   ### 2. 每轮对话显示 token / 成本 / 上下文占用（`tui-token-stats`）

   - 扩展 `turn:end` 事件的 usage payload，包含
   `input/output/cacheRead/cacheWrite/total/cost`
   - TUI 在每轮 assistant 回复后展示合并状态行：`📊 12.4k↓ 3.2k↑ · ▓▓ 77% · 💰
   $0.0032`
   - 上下文占用按阈值着色：≤80% dim / >80% yellow / >95% red

   ### Changes

   | File | Change |
   |------|--------|
   | `src/core/events.ts` | `turn:end` usage 类型扩展 |
   | `src/core/harness.ts` | 映射完整 usage 到事件 |
   | `src/ui/conversation.ts` | `renderLive(false)` + `startTurn` 强制刷新 |
   | `src/ui/tui-app.ts` | `formatTokens`/`formatCost`/`formatContextPercent` +
   合并渲染 |
   | `src/ui/tui-backend.ts` | 透传 `e.usage` |
   | `openspec/` | 2 个新 spec + 1 个修改 + 2 个 change 归档 |