### PR TITLE
feat: file upload polish, WebUI fixes, and OpenSpec workflow improvements

### DIFF
--- a/.dscode/commands/opsx/archive.md
+++ b/.dscode/commands/opsx/archive.md
@@ -7,171 +7,41 @@ tags: [workflow, archive, experimental]
 
 Archive a completed change in the experimental workflow.
 
-**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+**Store selection:** If the user names a store, run `npx openspec store list --json` to discover registered store ids, then pass `--store <id>` on commands that read or write specs and changes. Without a store, commands act on the nearest local `openspec/` root.
 
-**Input**: Optionally specify a change name after `/opsx:archive` (e.g., `/opsx:archive add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+**Input**: Optionally specify a change name after `/opsx:archive` (e.g., `/opsx:archive add-auth`). If omitted, prompt for selection.
 
 **Steps**
 
-1. **If no change name provided, prompt for selection**
+1. **Select change** (if not provided)
 
-   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+   Run `npx openspec list --json`. Show active changes (not archived). Let user choose. Do NOT auto-select.
 
-   Show only active changes (not already archived).
-   Include the schema used for each change if available.
+2. **Generate consolidate** (MANDATORY for spec-driven-plus schemas)
 
-   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
-
-2. **Check artifact completion status**
-
-   Run `openspec status --change "<name>" --json` to check artifact completion.
-
-   Parse the JSON to understand:
-   - `schemaName`: The workflow being used
-   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context
-   - `artifacts`: List of artifacts with their status (`done` or other)
-
-   **If any artifacts are not `done`:**
-   - Display warning listing incomplete artifacts
-   - Prompt user for confirmation to continue
-   - Proceed if user confirms
-
-3. **Check task completion status**
-
-   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
-
-   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
-
-   **If incomplete tasks found:**
-   - Display warning showing count of incomplete tasks
-   - Prompt user for confirmation to continue
-   - Proceed if user confirms
-
-   **If no tasks file exists:** Proceed without task-related warning.
-
-4. **Assess delta spec sync state**
-
-   Use `artifactPaths.specs.existingOutputPaths` from status JSON to check for delta specs. If none exist, proceed without sync prompt.
-
-   **If delta specs exist:**
-   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
-   - Determine what changes would be applied (adds, modifications, removals, renames)
-   - Show a combined summary before prompting
-
-   **Prompt options:**
-   - If changes needed: "Sync now (recommended)", "Archive without syncing"
-   - If already synced: "Archive now", "Sync anyway", "Cancel"
-
-   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
-
-5. **Handle consolidate artifact (spec-driven-plus and derived schemas)**
-
-   Check `artifactPaths` from the status JSON for a `consolidate` artifact.
+   Run `npx openspec status --change "<name>" --json`. Check `artifactPaths` for a `consolidate` artifact.
 
    **If consolidate artifact exists:**
-   - Check if `consolidate.md` is `done` in the status
-   - **If not done:**
-     - Announce: "Generating consolidate merge before archive..."
-     - Run `openspec instructions consolidate --change "<name>" --json`
-     - Use the returned instruction + template to create `consolidate.md`
-     - This merges the current proposal with related archived change proposals
-     - Show a brief summary: merged N related changes, timeline from X to Y
-   - **If already done:**
-     - Note: "consolidate.md already exists" and proceed
+   - This step is MANDATORY. Do NOT skip it.
+   - Run `npx openspec instructions consolidate --change "<name>" --json`
+   - Scan `openspec/changes/archive/` for related changes (match by capability keywords, file paths, topic)
+   - Read current proposal.md + related archived proposals
+   - Write consolidate.md using the returned template (overwrite if exists)
+   - Show: "Merged N related changes, timeline from YYYY-MM-DD to YYYY-MM-DD"
 
-   **If no consolidate artifact:** Skip this step (schema doesn't support it).
+   **If no consolidate artifact:** Skip to step 3.
 
-6. **Perform the archive**
+3. **Archive**
 
-   Create an `archive` directory under `planningHome.changesDir` if it doesn't exist:
-   ```bash
-   mkdir -p "<planningHome.changesDir>/archive"
-   ```
+   Run `npx openspec archive <name> --yes`. This single command handles:
+   - Artifact completion check (proposal, specs, tasks)
+   - Task completion check
+   - Delta spec sync
+   - File move to archive
 
-   Generate target name using current date: `YYYY-MM-DD-<change-name>`
-
-   **Check if target already exists:**
-   - If yes: Fail with error, suggest renaming existing archive or using different date
-   - If no: Move `changeRoot` to the archive directory
-
-   ```bash
-   mv "<changeRoot>" "<planningHome.changesDir>/archive/YYYY-MM-DD-<name>"
-   ```
-
-7. **Display summary**
-
-   Show archive completion summary including:
-   - Change name
-   - Schema that was used
-   - Archive location
-   - Spec sync status (synced / sync skipped / no delta specs)
-   - Note about any warnings (incomplete artifacts/tasks)
-
-**Output On Success**
-
-```
-## Archive Complete
-
-**Change:** <change-name>
-**Schema:** <schema-name>
-**Archived to:** the archive path derived from `planningHome.changesDir`/YYYY-MM-DD-<name>/
-**Specs:** ✓ Synced to main specs
-
-All artifacts complete. All tasks complete.
-```
-
-**Output On Success (No Delta Specs)**
-
-```
-## Archive Complete
-
-**Change:** <change-name>
-**Schema:** <schema-name>
-**Archived to:** the archive path derived from `planningHome.changesDir`/YYYY-MM-DD-<name>/
-**Specs:** No delta specs
-
-All artifacts complete. All tasks complete.
-```
-
-**Output On Success With Warnings**
-
-```
-## Archive Complete (with warnings)
-
-**Change:** <change-name>
-**Schema:** <schema-name>
-**Archived to:** the archive path derived from `planningHome.changesDir`/YYYY-MM-DD-<name>/
-**Specs:** Sync skipped (user chose to skip)
-
-**Warnings:**
-- Archived with 2 incomplete artifacts
-- Archived with 3 incomplete tasks
-- Delta spec sync was skipped (user chose to skip)
-
-Review the archive if this was not intentional.
-```
-
-**Output On Error (Archive Exists)**
-
-```
-## Archive Failed
-
-**Change:** <change-name>
-**Target:** the archive path derived from `planningHome.changesDir`/YYYY-MM-DD-<name>/
-
-Target archive directory already exists.
-
-**Options:**
-1. Rename the existing archive
-2. Delete the existing archive if it's a duplicate
-3. Wait until a different date to archive
-```
+   If it fails, fix the reported errors and re-run.
 
 **Guardrails**
-- Always prompt for change selection if not provided
-- Use artifact graph (openspec status --json) for completion checking
-- Don't block archive on warnings - just inform and confirm
-- Preserve .openspec.yaml when moving to archive (it moves with the directory)
-- Show clear summary of what happened
-- If sync is requested, use the Skill tool to invoke `openspec-sync-specs` (agent-driven)
-- If delta specs exist, always run the sync assessment and show the combined summary before prompting
+- Step 2 (consolidate) is the ONLY step you control. `npx openspec archive` handles everything else.
+- NEVER skip step 2 for spec-driven-plus schemas.
+- Never manually move directories — always use `npx openspec archive --yes`.

--- a/.dscode/commands/opsx/explore.md
+++ b/.dscode/commands/opsx/explore.md
@@ -78,8 +78,8 @@ Depending on what the user brings, you might:
 - Find gaps in understanding
 - Suggest spikes or investigations
 **Create HTML prototypes for frontend ideas**
-- When the conversation touches UI/frontend topics, detect it naturally (keywords: UI, 页面, 界面, 组件, 交互, 样式, 视觉, CSS, frontend, landing, dashboard, 原型, prototype, redesign, 动效)
-- Offer: "这个话题涉及前端设计，要不要出一个 HTML 原型？"
+- When the conversation touches UI/frontend topics, detect it naturally (keywords: UI, page, component, interaction, style, visual, CSS, frontend, landing, dashboard, prototype, redesign, animation)
+- Offer: "This involves frontend design — want me to create an HTML prototype?"
 - If yes:
   1. Load `prototype-workflow` skill (auto-loads `html-output`)
   2. Extract `--color-*` CSS variables from `web/index.css`

--- a/.dscode/commands/opsx/explore.md
+++ b/.dscode/commands/opsx/explore.md
@@ -90,6 +90,30 @@ Depending on what the user brings, you might:
 > the prototype is confirmed or the user explicitly dismisses it.
 > This applies even when also discussing architecture, protocols, or backend.
 > UI + backend discussions require the prototype OFFER before the spec WRITE.
+>
+> ⚠️ **PRE-OUTPUT GATE (HARD RULE)**: The Frontend Gate above is NOT triggered
+> only at "spec write time" — it must fire BEFORE you present any analysis, fix
+> plan, or recommendation that touches UI. The common failure mode is framing a
+> task as "bug fix" or "investigation", then outputting UI design decisions
+> (CSS changes, layout fixes, rendering improvements) without ever offering a
+> prototype. To prevent this, run this self-check BEFORE presenting any output:
+>
+> 1. Does my upcoming output touch UI components / layout / CSS / interaction /
+>    rendering / visual presentation? (Check both the user's request AND your
+>    own analysis findings — the user may not say "UI" but your investigation
+>    may reveal CSS, rendering, layout, or component issues.)
+> 2. If YES → offer the prototype FIRST, then pause. Do NOT present the analysis
+>    or fix plan until the prototype is confirmed or dismissed.
+> 3. If NO → continue normally.
+>
+> Trigger keywords (non-exhaustive, includes both user-facing and internally
+> discovered terms): UI, page, component, interaction, style, visual, CSS,
+> frontend, landing, dashboard, prototype, redesign, animation, rendering,
+> layout, spacing, markup, DOM, card, display, toast, modal, panel, picker,
+> button, border, color, font, overflow, height, width, padding.
+>
+> There is NO "but this is just a bug fix" exception. Bug fixes that change how
+> things look ARE UI design decisions.
 
 - When the conversation touches UI/frontend topics, detect it naturally (keywords: UI, page, component, interaction, style, visual, CSS, frontend, landing, dashboard, prototype, redesign, animation, rendering, layout, spacing, markup, DOM, card, display, toast, modal, panel, picker, button)
 - **ALWAYS offer** (not optional to skip): "This involves frontend design — want me to create an HTML prototype?"
@@ -100,8 +124,6 @@ Depending on what the user brings, you might:
   4. Iterate visually based on user feedback on the prototype
   5. When design is confirmed, capture decisions into `design.md` / `specs`
 - If user says no — continue, but the offer was made
-- Canonical example: session 00MRIZMZQJ (`docs/prototypes/mcp-toolcard-execution-view-prototype.html`)
-- Canonical example: session 00MRIZMZQJ (`docs/prototypes/mcp-toolcard-execution-view-prototype.html`)
 
 ---
 

--- a/.dscode/commands/opsx/explore.md
+++ b/.dscode/commands/opsx/explore.md
@@ -201,15 +201,14 @@ If the user mentions a change or you detect one is relevant:
 
 ## Ending Discovery
 
-There's no required ending. Discovery might:
-- **Before flowing into a proposal for frontend/UI changes**: "This involves frontend design — want to create an HTML prototype first?"
+When exploration is wrapping up, **always direct the user to `/opsx:propose`** as the next step. Never suggest `/opsx:apply` directly — the flow is explore → propose → apply.
 
-- **Flow into a proposal**: "Ready to start? I can create a change proposal."
-- **Result in artifact updates**: "Updated design.md with these decisions"
-- **Just provide clarity**: User has what they need, moves on
-- **Continue later**: "We can pick this up anytime"
+- **If an HTML prototype was created**: "Great, we've confirmed the visual direction. Run `/opsx:propose` next — the prototype will be incorporated into the change's prototype artifact."
+- **If no prototype was created**: "Run `/opsx:propose` next to create a change proposal with all artifacts."
+- **If the user wants to just capture clarity**: You may summarize key insights, but still end by suggesting `/opsx:propose` if they want to formalize.
+- **If the user wants to continue later**: "We can pick this up anytime — when ready, run `/opsx:propose` to formalize this into a change."
 
-When things crystallize, you might offer a summary - but it's optional. Sometimes the thinking IS the value.
+**NEVER suggest `/opsx:apply`** — apply is for implementing an existing change, not for starting from exploration.
 
 ---
 

--- a/.dscode/commands/opsx/explore.md
+++ b/.dscode/commands/opsx/explore.md
@@ -5,6 +5,10 @@ category: Workflow
 tags: [workflow, explore, experimental, thinking]
 ---
 
+# OPSX: Explore
+
+Enter explore mode - think through ideas, investigate problems, clarify requirements
+
 Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
 
 **IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
@@ -77,16 +81,26 @@ Depending on what the user brings, you might:
 - Identify what could go wrong
 - Find gaps in understanding
 - Suggest spikes or investigations
+
 **Create HTML prototypes for frontend ideas**
-- When the conversation touches UI/frontend topics, detect it naturally (keywords: UI, page, component, interaction, style, visual, CSS, frontend, landing, dashboard, prototype, redesign, animation)
-- Offer: "This involves frontend design — want me to create an HTML prototype?"
+
+> ⚠️ **FRONTEND GATE (HARD RULE)**: Before writing ANY spec requirement,
+> design decision, or task that touches UI components, layout, or interaction
+> patterns, you MUST offer a prototype. Do NOT write spec/design/tasks until
+> the prototype is confirmed or the user explicitly dismisses it.
+> This applies even when also discussing architecture, protocols, or backend.
+> UI + backend discussions require the prototype OFFER before the spec WRITE.
+
+- When the conversation touches UI/frontend topics, detect it naturally (keywords: UI, page, component, interaction, style, visual, CSS, frontend, landing, dashboard, prototype, redesign, animation, rendering, layout, spacing, markup, DOM, card, display, toast, modal, panel, picker, button)
+- **ALWAYS offer** (not optional to skip): "This involves frontend design — want me to create an HTML prototype?"
 - If yes:
   1. Load `prototype-workflow` skill (auto-loads `html-output`)
   2. Extract `--color-*` CSS variables from `web/index.css`
   3. Generate self-contained HTML at `docs/prototypes/<change-name>-<descriptor>.html`
   4. Iterate visually based on user feedback on the prototype
   5. When design is confirmed, capture decisions into `design.md` / `specs`
-- Prototype is optional — it never blocks apply
+- If user says no — continue, but the offer was made
+- Canonical example: session 00MRIZMZQJ (`docs/prototypes/mcp-toolcard-execution-view-prototype.html`)
 - Canonical example: session 00MRIZMZQJ (`docs/prototypes/mcp-toolcard-execution-view-prototype.html`)
 
 ---
@@ -127,14 +141,16 @@ If the user mentions a change or you detect one is relevant:
 
 2. **Reference them naturally in conversation**
    - "Your design mentions using Redis, but we just realized SQLite fits better..."
-    | Design insight for frontend | `docs/prototypes/<name>.html` |
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+    | ⚠️ Frontend/UI design        | **PROTOTYPE FIRST** — see Frontend Gate above. Then capture in `docs/prototypes/<name>.html` + `design.md` |
 
 3. **Offer to capture when decisions are made**
 
     | Insight Type               | Where to Capture               |
     |----------------------------|--------------------------------|
+- **Prototype before spec (HARD)**: Before writing any spec requirement, design decision, or task that involves UI components (toast, button, panel, picker, modal, input area), layout changes, or interaction patterns — ALWAYS offer an HTML prototype first. See Frontend Gate.
+- **Self-check before writing artifacts**: Does this change involve new UI? Existing component behavior changes? Am I about to write a scenario about toast/button/panel/picker/modal? → If yes to any, offer prototype first.
     | New requirement discovered | `specs/<capability>/spec.md` |
-    | Design insight for frontend | `docs/prototypes/<name>.html` |
     | Requirement changed        | `specs/<capability>/spec.md` |
     | Design decision made       | `design.md`                  |
     | Scope changed              | `proposal.md`                |
@@ -164,10 +180,10 @@ If the user mentions a change or you detect one is relevant:
 ## Ending Discovery
 
 There's no required ending. Discovery might:
+- **Before flowing into a proposal for frontend/UI changes**: "This involves frontend design — want to create an HTML prototype first?"
 
 - **Flow into a proposal**: "Ready to start? I can create a change proposal."
 - **Result in artifact updates**: "Updated design.md with these decisions"
-- **Flow into a prototype**: "This feels like it needs a frontend prototype. Want me to create one?"
 - **Just provide clarity**: User has what they need, moves on
 - **Continue later**: "We can pick this up anytime"
 

--- a/.dscode/commands/opsx/propose.md
+++ b/.dscode/commands/opsx/propose.md
@@ -31,13 +31,24 @@ When ready to implement, run /opsx:apply
 
    **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
 
-2. **Create the change directory**
+2. **Check for existing prototypes**
+
+   Before creating the change directory, check `docs/prototypes/` for HTML files
+   matching the change name (e.g., `<change-name>-*.html`):
+   - **If found**: Read the prototype HTML files — they are the design source-of-truth
+     from explore. These will be referenced in the prototype artifact.
+   - **If not found and the change involves UI**: Offer to generate a prototype first
+     using the `prototype-workflow` skill, or proceed if the user prefers to skip.
+   - **If not found and the change is non-UI**: Proceed — a non-UI stub prototype
+     artifact will be created during artifact generation.
+
+3. **Create the change directory**
    ```bash
    openspec new change "<name>"
    ```
    This creates a scaffolded change in the planning home resolved by the CLI with `.openspec.yaml`.
 
-3. **Get the artifact build order**
+4. **Get the artifact build order**
    ```bash
    openspec status --change "<name>" --json
    ```
@@ -46,7 +57,7 @@ When ready to implement, run /opsx:apply
    - `artifacts`: list of all artifacts with their status and dependencies
    - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context. Use these instead of assuming repo-local paths.
 
-4. **Create artifacts in sequence until apply-ready**
+5. **Create artifacts in sequence until apply-ready**
 
    Use the **TodoWrite tool** to track progress through the artifacts.
 
@@ -78,7 +89,7 @@ When ready to implement, run /opsx:apply
       - Use **AskUserQuestion tool** to clarify
       - Then continue with creation
 
-5. **Show final status**
+6. **Show final status**
    ```bash
    openspec status --change "<name>"
    ```

--- a/.dscode/skills/openspec-explore/SKILL.md
+++ b/.dscode/skills/openspec-explore/SKILL.md
@@ -249,30 +249,14 @@ You: That changes everything.
 
 ## Ending Discovery
 
-There's no required ending. Discovery might:
+When exploration is wrapping up, **always direct the user to `/opsx:propose`** as the next step. Never suggest `/opsx:apply` directly — the flow is explore → propose → apply.
 
-- **Flow into a proposal**: "Ready to start? I can create a change proposal."
-- **Result in artifact updates**: "Updated design.md with these decisions"
-- **Just provide clarity**: User has what they need, moves on
-- **Continue later**: "We can pick this up anytime"
+- **If an HTML prototype was created**: "Great, we've confirmed the visual direction. Run `/opsx:propose` next — the prototype will be incorporated into the change's prototype artifact."
+- **If no prototype was created**: "Run `/opsx:propose` next to create a change proposal with all artifacts."
+- **If the user wants to just capture clarity**: You may summarize key insights, but still end by suggesting `/opsx:propose` if they want to formalize.
+- **If the user wants to continue later**: "We can pick this up anytime — when ready, run `/opsx:propose` to formalize this into a change."
 
-When it feels like things are crystallizing, you might summarize:
-
-```
-## What We Figured Out
-
-**The problem**: [crystallized understanding]
-
-**The approach**: [if one emerged]
-
-**Open questions**: [if any remain]
-
-**Next steps** (if ready):
-- Create a change proposal
-- Keep exploring: just keep talking
-```
-
-But this summary is optional. Sometimes the thinking IS the value.
+**NEVER suggest `/opsx:apply`** — apply is for implementing an existing change, not for starting from exploration.
 
 ---
 

--- a/.dscode/skills/openspec-propose/SKILL.md
+++ b/.dscode/skills/openspec-propose/SKILL.md
@@ -33,13 +33,24 @@ When ready to implement, run /opsx:apply
 
    **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
 
-2. **Create the change directory**
+2. **Check for existing prototypes**
+
+   Before creating the change directory, check `docs/prototypes/` for HTML files
+   matching the change name (e.g., `<change-name>-*.html`):
+   - **If found**: Read the prototype HTML files — they are the design source-of-truth
+     from explore. These will be referenced in the prototype artifact.
+   - **If not found and the change involves UI**: Offer to generate a prototype first
+     using the `prototype-workflow` skill, or proceed if the user prefers to skip.
+   - **If not found and the change is non-UI**: Proceed — a non-UI stub prototype
+     artifact will be created during artifact generation.
+
+3. **Create the change directory**
    ```bash
    openspec new change "<name>"
    ```
    This creates a scaffolded change at `openspec/changes/<name>/` with `.openspec.yaml`.
 
-3. **Get the artifact build order**
+4. **Get the artifact build order**
    ```bash
    openspec status --change "<name>" --json
    ```
@@ -47,7 +58,7 @@ When ready to implement, run /opsx:apply
    - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
    - `artifacts`: list of all artifacts with their status and dependencies
 
-4. **Create artifacts in sequence until apply-ready**
+5. **Create artifacts in sequence until apply-ready**
 
    Use the **TodoWrite tool** to track progress through the artifacts.
 
@@ -79,7 +90,7 @@ When ready to implement, run /opsx:apply
       - Use **AskUserQuestion tool** to clarify
       - Then continue with creation
 
-5. **Show final status**
+6. **Show final status**
    ```bash
    openspec status --change "<name>"
    ```

--- a/.dscode/skills/prototype-workflow/SKILL.md
+++ b/.dscode/skills/prototype-workflow/SKILL.md
@@ -50,7 +50,7 @@ UI, 页面, 界面, 组件, 交互, 样式, 视觉, CSS, frontend, landing, dash
 3. 生成自包含 HTML → `docs/prototypes/<change-name>-<descriptor>.html`
 4. HTML 文件必须包含多状态切换按钮（如 waiting / in-progress / done / error），便于视觉迭代
 5. 在原型上直接接收视觉反馈并迭代，直到用户确认
-6. 确认后将最终设计决策写入对应 change 的 `design.md` / `specs`
+6. 确认后引导用户运行 `/opsx:propose` — 原型将作为 change 的 prototype artifact 被整合
 
 ## 生命周期
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,15 @@ isMcpToolName(name)                  → boolean
 - `~/.mcp.json` — 用户全局 MCP servers，包含敏感信息不提交
 - `<project>/.mcp.json` — 项目 MCP servers，应加入 `.gitignore`
 
+## Command & Skill File Priority
+
+Commands and skills may coexist in three locations: `.dscode/`, `.clinerules/`, `.claude/`.
+
+- **`.dscode/commands/` / `.dscode/skills/` is the canonical source**
+- **`.clinerules/` and `.claude/` are sync copies**
+- When modifying commands or skills, **must update all three locations**, with `.dscode/` as the authority
+- When searching for command definitions, **read `.dscode/` first** — do not stop at `.clinerules/` or `.claude/`
+
 ## 日志排查
 
 当需要追踪运行时执行路径时，使用项目内置的 Logger（**禁止 `console.log`**，TUI 独占终端，stdout 不可见）。

--- a/docs/prototypes/builtin-tool-result-rendering-fix-v2.html
+++ b/docs/prototypes/builtin-tool-result-rendering-fix-v2.html
@@ -1,0 +1,601 @@
+<!DOCTYPE html>
+<!--
+  Change: builtin-tool-result-rendering-fix-v2
+  Date: 2025-01-20
+  Description: Fix CSS conflicts, MCP raw block plain text, char limit, and blank space.
+               Shows before (broken) vs after (fixed) for built-in + MCP tool rendering.
+-->
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Tool Result Rendering v2 — Before vs After</title>
+<style>
+  :root {
+    --color-bg: #f8f7f5;
+    --color-surface: #f3f2ef;
+    --color-surface-hover: #ebe9e5;
+    --color-border: #e6e4e0;
+    --color-text: #2d2a26;
+    --color-text-muted: #8a8580;
+    --color-accent: #ca8a04;
+    --color-accent-hover: #a07004;
+    --color-accent-bg: rgba(202, 138, 4, 0.12);
+    --color-success: #edf4ed;
+    --color-success-text: #347539;
+    --color-error: #fdebec;
+    --color-error-text: #9f2f2d;
+    --color-warning: #fbf3db;
+    --color-warning-text: #956400;
+  }
+
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+
+  body {
+    font-family: 'Geist Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    background: var(--color-bg);
+    color: var(--color-text);
+    padding: 32px 24px;
+    min-height: 100vh;
+  }
+
+  /* ── Page Header ── */
+  .page-header { max-width: 920px; margin: 0 auto 28px; }
+  .page-header h1 { font-size: 20px; font-weight: 700; letter-spacing: -0.01em; margin-bottom: 6px; }
+  .page-header p { font-size: 13px; color: var(--color-text-muted); line-height: 1.5; }
+
+  /* ── Toggle Bar ── */
+  .toggle-bar { max-width: 920px; margin: 0 auto 24px; display: flex; align-items: center; gap: 12px; }
+  .toggle-group { display: inline-flex; background: var(--color-surface); border: 1px solid var(--color-border); border-radius: 8px; padding: 3px; }
+  .toggle-btn { padding: 7px 18px; font-size: 12px; font-weight: 600; border: none; background: transparent; color: var(--color-text-muted); cursor: pointer; border-radius: 6px; transition: all 0.15s; font-family: inherit; }
+  .toggle-btn.active { background: var(--color-accent); color: #fff; }
+  .toggle-btn:not(.active):hover { background: var(--color-surface-hover); color: var(--color-text); }
+  .toggle-label { font-size: 11px; color: var(--color-text-muted); font-family: 'Geist Mono', monospace; }
+
+  /* ── Comparison ── */
+  .comparison { max-width: 920px; margin: 0 auto; display: grid; grid-template-columns: 1fr 1fr; gap: 20px; }
+  .col-header { font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em; color: var(--color-text-muted); margin-bottom: 10px; display: flex; align-items: center; gap: 8px; }
+  .tag { font-size: 9px; padding: 2px 7px; border-radius: 10px; font-weight: 700; }
+  .tag-broken { background: var(--color-error); color: var(--color-error-text); }
+  .tag-fixed { background: var(--color-success); color: var(--color-success-text); }
+
+  /* ── Tool Card (shared) ── */
+  .tool-card { background: var(--color-surface); border: 1px solid var(--color-border); border-radius: 6px; overflow: hidden; margin-bottom: 14px; }
+  .tool-card.mcp { border-left: 2px solid var(--color-accent); }
+  .tool-card-header { display: flex; align-items: center; gap: 10px; padding: 8px 14px; cursor: pointer; user-select: none; }
+  .tool-card-header .status { font-size: 11px; width: 18px; height: 18px; display: flex; align-items: center; justify-content: center; border-radius: 4px; font-weight: 700; flex-shrink: 0; }
+  .tool-card-header .status.ok { background: var(--color-success); color: var(--color-success-text); }
+  .tool-card-header .name { font-family: 'Geist Mono', 'JetBrains Mono', monospace; font-size: 11px; font-weight: 600; color: var(--color-accent); }
+  .tool-card-header .args { font-size: 11px; color: var(--color-text-muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 1; }
+  .tool-card-header .arrow { font-size: 9px; color: var(--color-text-muted); opacity: 0.4; flex-shrink: 0; transition: transform 0.3s; }
+  .tool-card.open .tool-card-header .arrow { transform: rotate(180deg); }
+  .mcp-badge { display: inline-block; font-family: 'Geist Mono', monospace; font-size: 8px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em; padding: 1px 5px; border-radius: 3px; background: var(--color-accent-bg); color: var(--color-accent); flex-shrink: 0; }
+  .tool-card-body { max-height: 0; overflow: hidden; transition: max-height 0.3s ease; }
+  .tool-card.open .tool-card-body { max-height: 800px; }
+
+  /* ════════ BEFORE: broken CSS ════════ */
+  .tool-card-body-inner-broken {
+    padding: 0 14px 12px;
+    font-family: 'Geist Mono', 'JetBrains Mono', monospace;  /* PROBLEM: overrides Markdown */
+    font-size: 11px;
+    line-height: 1.5;
+    color: var(--color-text-muted);                           /* PROBLEM: forces muted */
+    border-top: 1px solid var(--color-border);
+    padding-top: 10px;
+    margin-top: 2px;
+    max-height: 320px;
+    overflow-y: auto;
+    white-space: pre-wrap;                                    /* PROBLEM: inherited by <pre> */
+    word-break: break-word;
+  }
+  /* Simulate what Markdown renders when CSS conflicts exist */
+  .broken-md pre {
+    background: var(--color-bg);
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    padding: 12px;
+    overflow-x: auto;            /* useless — pre-wrap makes text wrap instead */
+    margin: 8px 0;              /* my-2 causes blank space */
+    font-size: 12px;
+    white-space: pre-wrap;      /* INHERITED from parent! */
+    word-break: break-word;
+    color: var(--color-text-muted);
+  }
+  .broken-md p { color: var(--color-text-muted); font-family: 'Geist Mono', monospace; font-size: 11px; }
+
+  /* Simulate: single-line JSON that wasn't pretty-printed (truncated at 600 chars) */
+  .broken-single-line-json {
+    font-family: 'Geist Mono', monospace;
+    font-size: 11px;
+    color: var(--color-text-muted);
+    white-space: pre-wrap;
+    word-break: break-word;
+    line-height: 1.5;
+  }
+
+  /* ════════ AFTER: fixed CSS ════════ */
+  .tool-card-body-inner-fixed {
+    padding: 8px 14px 10px;
+    border-top: 1px solid var(--color-border);
+    margin-top: 2px;
+    max-height: 400px;
+    overflow-y: auto;
+    /* NO font-family, NO color, NO white-space — let Markdown own its styling */
+  }
+  .fixed-md pre {
+    background: var(--color-bg);
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    padding: 10px 12px;
+    overflow-x: auto;
+    margin: 4px 0;              /* reduced from 8px */
+    white-space: pre;           /* explicit — not inherited from parent */
+    font-family: 'Geist Mono', 'JetBrains Mono', monospace;
+    font-size: 11px;
+    line-height: 1.55;
+    color: var(--color-text);
+  }
+  .fixed-md pre .code-lang {
+    display: block;
+    font-size: 9px;
+    color: var(--color-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin-bottom: 6px;
+  }
+  .fixed-md p {
+    font-family: 'Geist Sans', sans-serif;
+    font-size: 12px;
+    line-height: 1.6;
+    color: var(--color-text);
+    margin-bottom: 4px;
+  }
+  .fixed-md p:last-child { margin-bottom: 0; }
+  .fixed-md code {
+    font-family: 'Geist Mono', monospace;
+    font-size: 11px;
+    background: var(--color-accent-bg);
+    color: var(--color-accent);
+    padding: 1px 4px;
+    border-radius: 3px;
+  }
+  .fixed-md .truncate-hint {
+    font-size: 10px;
+    color: var(--color-text-muted);
+    font-style: italic;
+    margin-top: 4px;
+  }
+
+  /* ── MCP rich list (unchanged) ── */
+  .mcp-rich-list { display: flex; flex-direction: column; border-top: 1px solid var(--color-border); }
+  .mcp-rich-item { padding: 12px 14px; background: var(--color-bg); border-bottom: 1px solid var(--color-border); font-family: 'Geist Sans', sans-serif; }
+  .mcp-rich-item:last-child { border-bottom: none; }
+  .mcp-rich-item .r-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; margin-bottom: 6px; }
+  .mcp-rich-item .r-title { font-size: 13px; font-weight: 600; color: var(--color-text); line-height: 1.4; }
+  .mcp-rich-item .r-url { font-family: 'Geist Mono', monospace; font-size: 10px; color: var(--color-accent); opacity: 0.7; margin-bottom: 6px; word-break: break-all; }
+  .mcp-rich-item .r-content { font-size: 12px; color: var(--color-text-muted); line-height: 1.55; }
+
+  /* ── BEFORE: MCP raw block (plain text) ── */
+  .mcp-raw-block-broken {
+    padding: 12px 14px;
+    border-top: 1px solid var(--color-border);
+    font-family: 'Geist Mono', monospace;
+    font-size: 11px;
+    line-height: 1.55;
+    color: var(--color-text-muted);
+    max-height: 280px;
+    overflow-y: auto;
+    white-space: pre-wrap;
+    word-break: break-all;
+    background: var(--color-bg);
+  }
+
+  /* ── AFTER: MCP raw block with Markdown ── */
+  .mcp-raw-block-fixed {
+    padding: 8px 14px 10px;
+    border-top: 1px solid var(--color-border);
+    max-height: 400px;
+    overflow-y: auto;
+    background: var(--color-bg);
+  }
+
+  /* ── Section labels ── */
+  .section-label { max-width: 920px; margin: 24px auto 10px; font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em; color: var(--color-text-muted); padding-bottom: 8px; border-bottom: 1px solid var(--color-border); }
+  .section-label:first-of-type { margin-top: 0; }
+
+  /* ── Annotations ── */
+  .annotation { max-width: 920px; margin: 8px auto 0; padding: 10px 14px; background: var(--color-warning); border-radius: 6px; font-size: 11px; color: var(--color-warning-text); line-height: 1.5; display: flex; align-items: flex-start; gap: 8px; }
+  .annotation .ann-icon { flex-shrink: 0; font-weight: 700; }
+  .annotation.ok { background: var(--color-success); color: var(--color-success-text); }
+  .hidden { display: none !important; }
+</style>
+</head>
+<body>
+
+<div class="page-header">
+  <h1>Tool Result Rendering v2 — Before vs After</h1>
+  <p>Fixes: (1) CSS conflicts on <code>.tool-card-body-inner</code> breaking Markdown code blocks, (2) MCP raw block plain text → Markdown, (3) char limit 600→2000, (4) blank space from <code>my-2</code> margins.</p>
+</div>
+
+<div class="toggle-bar">
+  <div class="toggle-group">
+    <button class="toggle-btn active" data-mode="side">Side by Side</button>
+    <button class="toggle-btn" data-mode="before">Before Only</button>
+    <button class="toggle-btn" data-mode="after">After Only</button>
+  </div>
+  <span class="toggle-label" id="modeLabel">Showing both columns</span>
+</div>
+
+<!-- ════════ Section 1: Built-in tool — JSON result ════════ -->
+<div class="section-label">1. Built-in tool — JSON result (e.g. list_files, edit)</div>
+
+<div class="comparison" id="comp-1">
+  <!-- BEFORE -->
+  <div class="col-before">
+    <div class="col-header">Before <span class="tag tag-broken">BROKEN</span></div>
+    <div class="tool-card open">
+      <div class="tool-card-header">
+        <span class="status ok">✓</span>
+        <span class="name">list_files</span>
+        <span class="args">path: src/ui</span>
+        <span class="arrow">▾</span>
+      </div>
+      <div class="tool-card-body">
+        <div class="tool-card-body-inner-broken">
+          <div class="broken-md">
+            <pre><code>{"path":"src/ui/backend.ts","isDir":false,"name":"backend.ts","depth":0},{"path":"src/ui/conversation.ts","isDir":false,"name":"conversation.ts","depth":0},{"path":"src/ui/mdx","isDir":true,"name":"mdx","depth":0},{"path":"src/ui/web","isDir":true,"name":"web","depth":0}
+… (847 more chars)</code></pre>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="annotation">
+      <span class="ann-icon">⚠</span>
+      <span>JSON not pretty-printed (or truncated at 600 chars mid-object). <code>white-space: pre-wrap</code> inherited by <code>&lt;pre&gt;</code> causes wrapping. <code>color: muted</code> + <code>font-family: monospace</code> override Markdown styling. Large blank space from <code>my-2</code> margin on <code>&lt;pre&gt;</code>.</span>
+    </div>
+  </div>
+
+  <!-- AFTER -->
+  <div class="col-after">
+    <div class="col-header">After <span class="tag tag-fixed">FIXED</span></div>
+    <div class="tool-card open">
+      <div class="tool-card-header">
+        <span class="status ok">✓</span>
+        <span class="name">list_files</span>
+        <span class="args">path: src/ui</span>
+        <span class="arrow">▾</span>
+      </div>
+      <div class="tool-card-body">
+        <div class="tool-card-body-inner-fixed">
+          <div class="fixed-md">
+            <pre><span class="code-lang">json</span>[
+  {
+    "path": "src/ui/backend.ts",
+    "isDir": false,
+    "name": "backend.ts",
+    "depth": 0
+  },
+  {
+    "path": "src/ui/conversation.ts",
+    "isDir": false,
+    "name": "conversation.ts",
+    "depth": 0
+  },
+  {
+    "path": "src/ui/mdx",
+    "isDir": true,
+    "name": "mdx",
+    "depth": 0
+  },
+  {
+    "path": "src/ui/web",
+    "isDir": true,
+    "name": "web",
+    "depth": 0
+  }
+]</pre>
+            <div class="truncate-hint">… 847 more chars (limit: 2000)</div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="annotation ok">
+      <span class="ann-icon">✓</span>
+      <span>JSON pretty-printed with 2-space indent. <code>&lt;pre&gt;</code> has explicit <code>white-space: pre</code> — no wrapping. No <code>font-family</code>/<code>color</code> on container — Markdown owns styling. Char limit raised to 2000. Reduced margin (4px vs 8px).</span>
+    </div>
+  </div>
+</div>
+
+<!-- ════════ Section 2: Built-in tool — bash output ════════ -->
+<div class="section-label">2. Built-in tool — bash output (code block with blank space)</div>
+
+<div class="comparison" id="comp-2">
+  <div class="col-before">
+    <div class="col-header">Before <span class="tag tag-broken">BLANK SPACE</span></div>
+    <div class="tool-card open">
+      <div class="tool-card-header">
+        <span class="status ok">✓</span>
+        <span class="name">bash</span>
+        <span class="args">npm test</span>
+        <span class="arrow">▾</span>
+      </div>
+      <div class="tool-card-body">
+        <div class="tool-card-body-inner-broken">
+          <div class="broken-md">
+            <pre><code>PASS  src/ui/shared/reducer.test.ts
+PASS  src/utils/image.test.ts
+PASS  src/session/store.test.ts
+PASS  src/permissions/fuzzy.test.ts
+PASS  src/drivers/edit/hash.test.ts
+
+Tests:       5 passed, 5 total
+Time:        3.2s</code></pre>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="annotation">
+      <span class="ann-icon">⚠</span>
+      <span>Visible blank space above and below the code block from <code>my-2</code> (8px top + 8px bottom = 16px margin) + container <code>padding-top: 10px</code> + <code>padding-bottom: 12px</code> = 38px total vertical padding around content. Code block text forced to <code>color: muted</code> by parent.</span>
+    </div>
+  </div>
+
+  <div class="col-after">
+    <div class="col-header">After <span class="tag tag-fixed">FIXED</span></div>
+    <div class="tool-card open">
+      <div class="tool-card-header">
+        <span class="status ok">✓</span>
+        <span class="name">bash</span>
+        <span class="args">npm test</span>
+        <span class="arrow">▾</span>
+      </div>
+      <div class="tool-card-body">
+        <div class="tool-card-body-inner-fixed">
+          <div class="fixed-md">
+            <pre><span class="code-lang">sh</span>PASS  src/ui/shared/reducer.test.ts
+PASS  src/utils/image.test.ts
+PASS  src/session/store.test.ts
+PASS  src/permissions/fuzzy.test.ts
+PASS  src/drivers/edit/hash.test.ts
+
+Tests:       5 passed, 5 total
+Time:        3.2s</pre>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="annotation ok">
+      <span class="ann-icon">✓</span>
+      <span>Tight padding (8px top + 10px bottom). <code>&lt;pre&gt;</code> margin reduced to 4px. Text uses <code>color: text</code> (not muted). Language label shown.</span>
+    </div>
+  </div>
+</div>
+
+<!-- ════════ Section 3: MCP tool — non-JSON result (raw block) ════════ -->
+<div class="section-label">3. MCP tool — text result (was plain text, now Markdown)</div>
+
+<div class="comparison" id="comp-3">
+  <div class="col-before">
+    <div class="col-header">Before <span class="tag tag-broken">PLAIN TEXT</span></div>
+    <div class="tool-card mcp open">
+      <div class="tool-card-header">
+        <span class="status ok">✓</span>
+        <span class="name">mcp__github__get_file</span>
+        <span class="mcp-badge">MCP</span>
+        <span class="args">repo: dscode, path: README.md</span>
+        <span class="arrow">▾</span>
+      </div>
+      <div class="tool-card-body">
+        <div class="mcp-raw-block-broken"># DSCode\n\nA digital studio for content-driven creation.\n\n## Features\n\n- **Writing** — AI-assisted editing\n- **Code** — Full development environment\n- **Visual** — Brand and design tools\n\n## Installation\n\n```bash\nnpm install -g dscode\n```\n\n## Usage\n\nRun `dscode` to start the REPL.\n\nFor web mode: `dscode --web`</div>
+      </div>
+    </div>
+    <div class="annotation">
+      <span class="ann-icon">⚠</span>
+      <span>MCP raw block renders <code>{tool.result}</code> as plain text — no Markdown. <code>\n</code> shows as literal characters. <code>word-break: break-all</code> mangles URLs and code. No syntax highlighting.</span>
+    </div>
+  </div>
+
+  <div class="col-after">
+    <div class="col-header">After <span class="tag tag-fixed">MARKDOWN</span></div>
+    <div class="tool-card mcp open">
+      <div class="tool-card-header">
+        <span class="status ok">✓</span>
+        <span class="name">mcp__github__get_file</span>
+        <span class="mcp-badge">MCP</span>
+        <span class="args">repo: dscode, path: README.md</span>
+        <span class="arrow">▾</span>
+      </div>
+      <div class="tool-card-body">
+        <div class="mcp-raw-block-fixed">
+          <div class="fixed-md">
+            <h3 style="font-size:14px;font-weight:700;margin-bottom:6px;color:var(--color-text);">DSCode</h3>
+            <p>A digital studio for content-driven creation.</p>
+            <p style="font-weight:600;margin-top:8px;">Features</p>
+            <p>• <strong>Writing</strong> — AI-assisted editing<br>
+               • <strong>Code</strong> — Full development environment<br>
+               • <strong>Visual</strong> — Brand and design tools</p>
+            <p style="font-weight:600;margin-top:8px;">Installation</p>
+            <pre><span class="code-lang">bash</span>npm install -g dscode</pre>
+            <p style="font-weight:600;margin-top:8px;">Usage</p>
+            <p>Run <code>dscode</code> to start the REPL.</p>
+            <p>For web mode: <code>dscode --web</code></p>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="annotation ok">
+      <span class="ann-icon">✓</span>
+      <span>MCP raw block now uses <code>&lt;Markdown&gt;</code> — headings, lists, code blocks, inline code all rendered. Same CSS cleanup as built-in tools.</span>
+    </div>
+  </div>
+</div>
+
+<!-- ════════ Section 4: MCP tool — JSON without rich list fields ════════ -->
+<div class="section-label">4. MCP tool — JSON result without rich-list fields (raw JSON)</div>
+
+<div class="comparison" id="comp-4">
+  <div class="col-before">
+    <div class="col-header">Before <span class="tag tag-broken">PLAIN JSON</span></div>
+    <div class="tool-card mcp open">
+      <div class="tool-card-header">
+        <span class="status ok">✓</span>
+        <span class="name">mcp__db__query</span>
+        <span class="mcp-badge">MCP</span>
+        <span class="args">SELECT * FROM users LIMIT 3</span>
+        <span class="arrow">▾</span>
+      </div>
+      <div class="tool-card-body">
+        <div class="mcp-raw-block-broken">{"rows":[{"id":1,"name":"Alice","email":"alice@example.com","created_at":"2024-01-15T10:30:00Z"},{"id":2,"name":"Bob","email":"bob@example.com","created_at":"2024-01-16T08:15:00Z"},{"id":3,"name":"Charlie","email":"charlie@example.com","created_at":"2024-01-17T14:45:00Z"}],"count":3}</div>
+      </div>
+    </div>
+    <div class="annotation">
+      <span class="ann-icon">⚠</span>
+      <span>JSON without title/url/content fields → falls to raw block → single-line plain text. No pretty-printing, no code fence.</span>
+    </div>
+  </div>
+
+  <div class="col-after">
+    <div class="col-header">After <span class="tag tag-fixed">MARKDOWN JSON</span></div>
+    <div class="tool-card mcp open">
+      <div class="tool-card-header">
+        <span class="status ok">✓</span>
+        <span class="name">mcp__db__query</span>
+        <span class="mcp-badge">MCP</span>
+        <span class="args">SELECT * FROM users LIMIT 3</span>
+        <span class="arrow">▾</span>
+      </div>
+      <div class="tool-card-body">
+        <div class="mcp-raw-block-fixed">
+          <div class="fixed-md">
+            <pre><span class="code-lang">json</span>{
+  "rows": [
+    {
+      "id": 1,
+      "name": "Alice",
+      "email": "alice@example.com",
+      "created_at": "2024-01-15T10:30:00Z"
+    },
+    {
+      "id": 2,
+      "name": "Bob",
+      "email": "bob@example.com",
+      "created_at": "2024-01-16T08:15:00Z"
+    },
+    {
+      "id": 3,
+      "name": "Charlie",
+      "email": "charlie@example.com",
+      "created_at": "2024-01-17T14:45:00Z"
+    }
+  ],
+  "count": 3
+}</pre>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="annotation ok">
+      <span class="ann-icon">✓</span>
+      <span>MCP raw block detects JSON → pretty-prints → wraps in <code>```json</code> code fence → Markdown renders as styled code block with horizontal scroll.</span>
+    </div>
+  </div>
+</div>
+
+<!-- ════════ Section 5: write_file summary ════════ -->
+<div class="section-label">5. write_file — summary (CSS conflict fix)</div>
+
+<div class="comparison" id="comp-5">
+  <div class="col-before">
+    <div class="col-header">Before <span class="tag tag-broken">MUTED + MONO</span></div>
+    <div class="tool-card open">
+      <div class="tool-card-header">
+        <span class="status ok">✓</span>
+        <span class="name">write_file</span>
+        <span class="args">src/index.ts</span>
+        <span class="arrow">▾</span>
+      </div>
+      <div class="tool-card-body">
+        <div class="tool-card-body-inner-broken">
+          <div class="broken-md">
+            <p>Written 23577 bytes to /path/to/src/index.ts</p>
+            <p>New file version: fv_2a818c68</p>
+            <p>… (8 more lines — anchor preview hidden)</p>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="annotation">
+      <span class="ann-icon">⚠</span>
+      <span>Summary text forced to <code>color: muted</code> + <code>font-family: monospace</code> by parent CSS. Paths and file versions not highlighted as inline code.</span>
+    </div>
+  </div>
+
+  <div class="col-after">
+    <div class="col-header">After <span class="tag tag-fixed">CLEAN</span></div>
+    <div class="tool-card open">
+      <div class="tool-card-header">
+        <span class="status ok">✓</span>
+        <span class="name">write_file</span>
+        <span class="args">src/index.ts</span>
+        <span class="arrow">▾</span>
+      </div>
+      <div class="tool-card-body">
+        <div class="tool-card-body-inner-fixed">
+          <div class="fixed-md">
+            <p>✓ Written 23,577 bytes to <code>/path/to/src/index.ts</code></p>
+            <p>New file version: <code>fv_2a818c68</code></p>
+            <div class="truncate-hint">… 8 more lines — anchor preview hidden</div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="annotation ok">
+      <span class="ann-icon">✓</span>
+      <span>Normal text color, sans-serif font. Paths and versions rendered as inline <code>code</code> by Markdown. Truncation hint styled as muted italic.</span>
+    </div>
+  </div>
+</div>
+
+<script>
+  const toggleBtns = document.querySelectorAll('.toggle-btn');
+  const modeLabel = document.getElementById('modeLabel');
+  const comparisons = document.querySelectorAll('.comparison');
+
+  toggleBtns.forEach(btn => {
+    btn.addEventListener('click', () => {
+      toggleBtns.forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+      const mode = btn.dataset.mode;
+      comparisons.forEach(comp => {
+        const before = comp.querySelector('.col-before');
+        const after = comp.querySelector('.col-after');
+        if (mode === 'side') {
+          before?.classList.remove('hidden');
+          after?.classList.remove('hidden');
+          comp.style.gridTemplateColumns = '1fr 1fr';
+          modeLabel.textContent = 'Showing both columns';
+        } else if (mode === 'before') {
+          before?.classList.remove('hidden');
+          after?.classList.add('hidden');
+          comp.style.gridTemplateColumns = '1fr';
+          modeLabel.textContent = 'Before only — current broken state';
+        } else if (mode === 'after') {
+          before?.classList.add('hidden');
+          after?.classList.remove('hidden');
+          comp.style.gridTemplateColumns = '1fr';
+          modeLabel.textContent = 'After only — proposed fix';
+        }
+      });
+    });
+  });
+
+  document.querySelectorAll('.tool-card-header').forEach(header => {
+    header.addEventListener('click', () => {
+      const card = header.closest('.tool-card');
+      card.classList.toggle('open');
+    });
+  });
+</script>
+
+</body>
+</html>

--- a/docs/prototypes/builtin-tool-result-rendering-fix-v3.html
+++ b/docs/prototypes/builtin-tool-result-rendering-fix-v3.html
@@ -1,0 +1,587 @@
+<!DOCTYPE html>
+<!--
+  Change: builtin-tool-result-rendering-fix-v2
+  Date: 2025-01-20
+  Descriptor: v3-compact-spacing-exploration
+  Description: Explore tighter spacing between ToolCard header and result content.
+               Shows 4 variants side by side — current, v2-fixed, compact, ultra-compact.
+               Includes toggle for code-block vs plain-text results.
+-->
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ToolCard Spacing v3 — Compact Exploration</title>
+<style>
+  :root {
+    --color-bg: #f8f7f5;
+    --color-surface: #f3f2ef;
+    --color-surface-hover: #ebe9e5;
+    --color-border: #e6e4e0;
+    --color-text: #2d2a26;
+    --color-text-muted: #8a8580;
+    --color-accent: #ca8a04;
+    --color-accent-hover: #a07004;
+    --color-accent-bg: rgba(202, 138, 4, 0.12);
+    --color-success: #edf4ed;
+    --color-success-text: #347539;
+    --color-error: #fdebec;
+    --color-error-text: #9f2f2d;
+    --color-warning: #fbf3db;
+    --color-warning-text: #956400;
+  }
+
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+
+  body {
+    font-family: 'Geist Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    background: var(--color-bg);
+    color: var(--color-text);
+    padding: 32px 24px;
+    min-height: 100vh;
+  }
+
+  /* ── Page Header ── */
+  .page-header { max-width: 1100px; margin: 0 auto 20px; }
+  .page-header h1 { font-size: 20px; font-weight: 700; letter-spacing: -0.01em; margin-bottom: 6px; }
+  .page-header p { font-size: 13px; color: var(--color-text-muted); line-height: 1.5; }
+
+  /* ── Toggle Bar ── */
+  .toggle-bar { max-width: 1100px; margin: 0 auto 20px; display: flex; align-items: center; gap: 16px; flex-wrap: wrap; }
+  .toggle-group { display: inline-flex; background: var(--color-surface); border: 1px solid var(--color-border); border-radius: 8px; padding: 3px; }
+  .toggle-btn { padding: 7px 16px; font-size: 12px; font-weight: 600; border: none; background: transparent; color: var(--color-text-muted); cursor: pointer; border-radius: 6px; transition: all 0.15s; font-family: inherit; }
+  .toggle-btn.active { background: var(--color-accent); color: #fff; }
+  .toggle-btn:not(.active):hover { background: var(--color-surface-hover); color: var(--color-text); }
+  .toggle-label { font-size: 11px; color: var(--color-text-muted); font-family: 'Geist Mono', monospace; }
+
+  /* ── Grid ── */
+  .grid { max-width: 1100px; margin: 0 auto; display: grid; grid-template-columns: 1fr 1fr; gap: 20px; }
+  .col { display: flex; flex-direction: column; gap: 8px; }
+  .col-header { font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em; color: var(--color-text-muted); display: flex; align-items: center; gap: 8px; margin-bottom: 4px; }
+  .tag { font-size: 9px; padding: 2px 7px; border-radius: 10px; font-weight: 700; }
+  .tag-current { background: var(--color-error); color: var(--color-error-text); }
+  .tag-v2 { background: var(--color-warning); color: var(--color-warning-text); }
+  .tag-compact { background: var(--color-success); color: var(--color-success-text); }
+  .tag-ultra { background: var(--color-accent-bg); color: var(--color-accent); }
+  .gap-info { font-size: 10px; color: var(--color-text-muted); font-family: 'Geist Mono', monospace; margin-bottom: 6px; padding: 4px 8px; background: var(--color-surface); border-radius: 4px; border: 1px solid var(--color-border); }
+
+  /* ════════ Shared ToolCard Structure ════════ */
+  .tool-card { background: var(--color-surface); border: 1px solid var(--color-border); border-radius: 6px; overflow: hidden; }
+  .tool-card-header { display: flex; align-items: center; gap: 10px; padding: 8px 14px; cursor: pointer; user-select: none; }
+  .tool-card-header .status { font-size: 11px; width: 18px; height: 18px; display: flex; align-items: center; justify-content: center; border-radius: 4px; font-weight: 700; flex-shrink: 0; background: var(--color-success); color: var(--color-success-text); }
+  .tool-card-header .name { font-family: 'Geist Mono', 'JetBrains Mono', monospace; font-size: 11px; font-weight: 600; color: var(--color-accent); }
+  .tool-card-header .args { font-size: 11px; color: var(--color-text-muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 1; }
+  .tool-card-header .arrow { font-size: 9px; color: var(--color-text-muted); opacity: 0.4; flex-shrink: 0; transform: rotate(180deg); }
+
+  .tool-card-body { max-height: 800px; overflow: hidden; }
+
+  /* Markdown pre simulation */
+  .md-pre {
+    background: var(--color-bg);
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    overflow-x: auto;
+    font-family: 'Geist Mono', 'JetBrains Mono', monospace;
+    font-size: 11px;
+    line-height: 1.55;
+    color: var(--color-text);
+    white-space: pre;
+  }
+  .md-pre .code-lang { display: block; font-size: 9px; color: var(--color-text-muted); text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 4px; }
+  .md-p { font-family: 'Geist Sans', sans-serif; font-size: 12px; line-height: 1.6; color: var(--color-text); }
+
+  /* ════════ Variant A: Current (26px) ════════ */
+  .variant-current .tool-card-body-inner {
+    padding: 0 14px 12px;
+    border-top: 1px solid var(--color-border);
+    padding-top: 10px;
+    margin-top: 2px;
+    max-height: 400px;
+    overflow-y: auto;
+  }
+  .variant-current .md-pre { padding: 12px; margin: 4px 0; }
+
+  /* ════════ Variant B: v2 Fixed (22px) ════════ */
+  .variant-v2 .tool-card-body-inner {
+    padding: 8px 14px 10px;
+    border-top: 1px solid var(--color-border);
+    margin-top: 2px;
+    max-height: 400px;
+    overflow-y: auto;
+  }
+  .variant-v2 .md-pre { padding: 10px 12px; margin: 4px 0; }
+
+  /* ════════ Variant C: Compact (16px) ════════ */
+  .variant-compact .tool-card-body-inner {
+    padding: 4px 14px 8px;
+    border-top: 1px solid var(--color-border);
+    margin-top: 0;
+    max-height: 400px;
+    overflow-y: auto;
+  }
+  .variant-compact .md-pre { padding: 8px 10px; margin: 2px 0; }
+
+  /* ════════ Variant D: Ultra-Compact / No Border (10px) ════════ */
+  .variant-ultra .tool-card-body-inner {
+    padding: 2px 14px 6px;
+    margin-top: 0;
+    max-height: 400px;
+    overflow-y: auto;
+    /* No border-top — use background contrast instead */
+  }
+  .variant-ultra .tool-card-header { border-bottom: none; }
+  .variant-ultra .md-pre { padding: 6px 10px; margin: 0; border: none; border-radius: 4px; }
+  .variant-ultra .md-p { margin: 0; }
+
+  /* ── Measurement overlay ── */
+  .measure-bar {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 10px;
+    font-family: 'Geist Mono', monospace;
+    color: var(--color-text-muted);
+    padding: 6px 14px;
+    background: var(--color-warning);
+    color: var(--color-warning-text);
+    border-radius: 0 0 6px 6px;
+    margin-top: -1px;
+  }
+  .measure-bar .arrow-down { font-size: 14px; }
+
+  /* ── Section labels ── */
+  .section-label { max-width: 1100px; margin: 28px auto 10px; font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em; color: var(--color-text-muted); padding-bottom: 8px; border-bottom: 1px solid var(--color-border); }
+  .section-label:first-of-type { margin-top: 0; }
+
+  /* ── Annotation ── */
+  .annotation { max-width: 1100px; margin: 8px auto 0; padding: 10px 14px; background: var(--color-surface); border-radius: 6px; font-size: 11px; color: var(--color-text-muted); line-height: 1.5; border: 1px solid var(--color-border); }
+  .annotation strong { color: var(--color-text); }
+
+  /* ── Plain text result style ── */
+  .plain-text-result {
+    font-family: 'Geist Sans', sans-serif;
+    font-size: 12px;
+    line-height: 1.6;
+    color: var(--color-text);
+  }
+
+  .hidden { display: none !important; }
+</style>
+</head>
+<body>
+
+<div class="page-header">
+  <h1>ToolCard Spacing v3 — Compact Exploration</h1>
+  <p>4 variants exploring tighter spacing between header and result content. Toggle between code-block and plain-text results. Numbers show total px from header bottom edge to first text character.</p>
+</div>
+
+<div class="toggle-bar">
+  <div class="toggle-group">
+    <button class="toggle-btn active" data-mode="code">Code Block Result</button>
+    <button class="toggle-btn" data-mode="text">Plain Text Result</button>
+  </div>
+  <span class="toggle-label" id="modeLabel">Showing code-block results (list_files / bash)</span>
+</div>
+
+<!-- ════════ Code Block Results ════════ -->
+<div id="code-results">
+
+<div class="section-label">list_files — JSON result</div>
+<div class="grid">
+
+  <!-- Variant A: Current -->
+  <div class="col">
+    <div class="col-header">A — Current <span class="tag tag-current">26px</span></div>
+    <div class="gap-info">margin-top:2 + border:1 + padding-top:10 + pre-margin:4 + pre-padding:12 = 29px</div>
+    <div class="tool-card variant-current">
+      <div class="tool-card-header">
+        <span class="status">✓</span>
+        <span class="name">list_files</span>
+        <span class="args">path: src/ui</span>
+        <span class="arrow">▾</span>
+      </div>
+      <div class="tool-card-body">
+        <div class="tool-card-body-inner">
+          <div class="md-pre"><span class="code-lang">json</span>[
+  { "path": "src/ui/backend.ts", "isDir": false, "name": "backend.ts", "depth": 0 },
+  { "path": "src/ui/conversation.ts", "isDir": false, "name": "conversation.ts", "depth": 0 },
+  { "path": "src/ui/mdx", "isDir": true, "name": "mdx", "depth": 0 },
+  { "path": "src/ui/web", "isDir": true, "name": "web", "depth": 0 }
+]</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Variant B: v2 Fixed -->
+  <div class="col">
+    <div class="col-header">B — v2 Fixed <span class="tag tag-v2">22px</span></div>
+    <div class="gap-info">margin-top:2 + border:1 + padding-top:8 + pre-margin:4 + pre-padding:10 = 25px</div>
+    <div class="tool-card variant-v2">
+      <div class="tool-card-header">
+        <span class="status">✓</span>
+        <span class="name">list_files</span>
+        <span class="args">path: src/ui</span>
+        <span class="arrow">▾</span>
+      </div>
+      <div class="tool-card-body">
+        <div class="tool-card-body-inner">
+          <div class="md-pre"><span class="code-lang">json</span>[
+  { "path": "src/ui/backend.ts", "isDir": false, "name": "backend.ts", "depth": 0 },
+  { "path": "src/ui/conversation.ts", "isDir": false, "name": "conversation.ts", "depth": 0 },
+  { "path": "src/ui/mdx", "isDir": true, "name": "mdx", "depth": 0 },
+  { "path": "src/ui/web", "isDir": true, "name": "web", "depth": 0 }
+]</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Variant C: Compact -->
+  <div class="col">
+    <div class="col-header">C — Compact <span class="tag tag-compact">16px</span></div>
+    <div class="gap-info">margin-top:0 + border:1 + padding-top:4 + pre-margin:2 + pre-padding:8 = 15px</div>
+    <div class="tool-card variant-compact">
+      <div class="tool-card-header">
+        <span class="status">✓</span>
+        <span class="name">list_files</span>
+        <span class="args">path: src/ui</span>
+        <span class="arrow">▾</span>
+      </div>
+      <div class="tool-card-body">
+        <div class="tool-card-body-inner">
+          <div class="md-pre"><span class="code-lang">json</span>[
+  { "path": "src/ui/backend.ts", "isDir": false, "name": "backend.ts", "depth": 0 },
+  { "path": "src/ui/conversation.ts", "isDir": false, "name": "conversation.ts", "depth": 0 },
+  { "path": "src/ui/mdx", "isDir": true, "name": "mdx", "depth": 0 },
+  { "path": "src/ui/web", "isDir": true, "name": "web", "depth": 0 }
+]</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Variant D: Ultra-Compact -->
+  <div class="col">
+    <div class="col-header">D — Ultra (no border) <span class="tag tag-ultra">10px</span></div>
+    <div class="gap-info">margin-top:0 + no-border + padding-top:2 + pre-margin:0 + pre-padding:6 = 8px</div>
+    <div class="tool-card variant-ultra">
+      <div class="tool-card-header">
+        <span class="status">✓</span>
+        <span class="name">list_files</span>
+        <span class="args">path: src/ui</span>
+        <span class="arrow">▾</span>
+      </div>
+      <div class="tool-card-body">
+        <div class="tool-card-body-inner">
+          <div class="md-pre"><span class="code-lang">json</span>[
+  { "path": "src/ui/backend.ts", "isDir": false, "name": "backend.ts", "depth": 0 },
+  { "path": "src/ui/conversation.ts", "isDir": false, "name": "conversation.ts", "depth": 0 },
+  { "path": "src/ui/mdx", "isDir": true, "name": "mdx", "depth": 0 },
+  { "path": "src/ui/web", "isDir": true, "name": "web", "depth": 0 }
+]</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+</div>
+
+<div class="section-label">bash — command output</div>
+<div class="grid">
+
+  <div class="col">
+    <div class="col-header">A — Current <span class="tag tag-current">26px</span></div>
+    <div class="tool-card variant-current">
+      <div class="tool-card-header">
+        <span class="status">✓</span>
+        <span class="name">bash</span>
+        <span class="args">npm test</span>
+        <span class="arrow">▾</span>
+      </div>
+      <div class="tool-card-body">
+        <div class="tool-card-body-inner">
+          <div class="md-pre"><span class="code-lang">sh</span>PASS  src/ui/shared/reducer.test.ts
+PASS  src/utils/image.test.ts
+PASS  src/session/store.test.ts
+PASS  src/permissions/fuzzy.test.ts
+PASS  src/drivers/edit/hash.test.ts
+
+Tests:       5 passed, 5 total
+Time:        3.2s</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="col">
+    <div class="col-header">B — v2 Fixed <span class="tag tag-v2">22px</span></div>
+    <div class="tool-card variant-v2">
+      <div class="tool-card-header">
+        <span class="status">✓</span>
+        <span class="name">bash</span>
+        <span class="args">npm test</span>
+        <span class="arrow">▾</span>
+      </div>
+      <div class="tool-card-body">
+        <div class="tool-card-body-inner">
+          <div class="md-pre"><span class="code-lang">sh</span>PASS  src/ui/shared/reducer.test.ts
+PASS  src/utils/image.test.ts
+PASS  src/session/store.test.ts
+PASS  src/permissions/fuzzy.test.ts
+PASS  src/drivers/edit/hash.test.ts
+
+Tests:       5 passed, 5 total
+Time:        3.2s</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="col">
+    <div class="col-header">C — Compact <span class="tag tag-compact">16px</span></div>
+    <div class="tool-card variant-compact">
+      <div class="tool-card-header">
+        <span class="status">✓</span>
+        <span class="name">bash</span>
+        <span class="args">npm test</span>
+        <span class="arrow">▾</span>
+      </div>
+      <div class="tool-card-body">
+        <div class="tool-card-body-inner">
+          <div class="md-pre"><span class="code-lang">sh</span>PASS  src/ui/shared/reducer.test.ts
+PASS  src/utils/image.test.ts
+PASS  src/session/store.test.ts
+PASS  src/permissions/fuzzy.test.ts
+PASS  src/drivers/edit/hash.test.ts
+
+Tests:       5 passed, 5 total
+Time:        3.2s</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="col">
+    <div class="col-header">D — Ultra (no border) <span class="tag tag-ultra">10px</span></div>
+    <div class="tool-card variant-ultra">
+      <div class="tool-card-header">
+        <span class="status">✓</span>
+        <span class="name">bash</span>
+        <span class="args">npm test</span>
+        <span class="arrow">▾</span>
+      </div>
+      <div class="tool-card-body">
+        <div class="tool-card-body-inner">
+          <div class="md-pre"><span class="code-lang">sh</span>PASS  src/ui/shared/reducer.test.ts
+PASS  src/utils/image.test.ts
+PASS  src/session/store.test.ts
+PASS  src/permissions/fuzzy.test.ts
+PASS  src/drivers/edit/hash.test.ts
+
+Tests:       5 passed, 5 total
+Time:        3.2s</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+</div>
+</div><!-- /code-results -->
+
+<!-- ════════ Plain Text Results ════════ -->
+<div id="text-results" class="hidden">
+
+<div class="section-label">read_file — text summary result</div>
+<div class="grid">
+
+  <div class="col">
+    <div class="col-header">A — Current <span class="tag tag-current">26px</span></div>
+    <div class="tool-card variant-current">
+      <div class="tool-card-header">
+        <span class="status">✓</span>
+        <span class="name">read_file</span>
+        <span class="args">path: src/ui/backend.ts</span>
+        <span class="arrow">▾</span>
+      </div>
+      <div class="tool-card-body">
+        <div class="tool-card-body-inner">
+          <div class="plain-text-result">Read 45 lines from src/ui/backend.ts. The file exports a Backend interface and a createBackend function that wires up WebSocket handlers for the TUI session.</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="col">
+    <div class="col-header">B — v2 Fixed <span class="tag tag-v2">22px</span></div>
+    <div class="tool-card variant-v2">
+      <div class="tool-card-header">
+        <span class="status">✓</span>
+        <span class="name">read_file</span>
+        <span class="args">path: src/ui/backend.ts</span>
+        <span class="arrow">▾</span>
+      </div>
+      <div class="tool-card-body">
+        <div class="tool-card-body-inner">
+          <div class="plain-text-result">Read 45 lines from src/ui/backend.ts. The file exports a Backend interface and a createBackend function that wires up WebSocket handlers for the TUI session.</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="col">
+    <div class="col-header">C — Compact <span class="tag tag-compact">16px</span></div>
+    <div class="tool-card variant-compact">
+      <div class="tool-card-header">
+        <span class="status">✓</span>
+        <span class="name">read_file</span>
+        <span class="args">path: src/ui/backend.ts</span>
+        <span class="arrow">▾</span>
+      </div>
+      <div class="tool-card-body">
+        <div class="tool-card-body-inner">
+          <div class="plain-text-result">Read 45 lines from src/ui/backend.ts. The file exports a Backend interface and a createBackend function that wires up WebSocket handlers for the TUI session.</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="col">
+    <div class="col-header">D — Ultra (no border) <span class="tag tag-ultra">10px</span></div>
+    <div class="tool-card variant-ultra">
+      <div class="tool-card-header">
+        <span class="status">✓</span>
+        <span class="name">read_file</span>
+        <span class="args">path: src/ui/backend.ts</span>
+        <span class="arrow">▾</span>
+      </div>
+      <div class="tool-card-body">
+        <div class="tool-card-body-inner">
+          <div class="plain-text-result">Read 45 lines from src/ui/backend.ts. The file exports a Backend interface and a createBackend function that wires up WebSocket handlers for the TUI session.</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+</div>
+
+<div class="section-label">grep — search result (mixed text + code)</div>
+<div class="grid">
+
+  <div class="col">
+    <div class="col-header">A — Current <span class="tag tag-current">26px</span></div>
+    <div class="tool-card variant-current">
+      <div class="tool-card-header">
+        <span class="status">✓</span>
+        <span class="name">grep</span>
+        <span class="args">pattern: ToolCard</span>
+        <span class="arrow">▾</span>
+      </div>
+      <div class="tool-card-body">
+        <div class="tool-card-body-inner">
+          <div class="plain-text-result">Found 3 matches in 2 files:<br><br>
+<span style="font-family:'Geist Mono',monospace;font-size:11px;color:var(--color-accent);">web/src/components/ToolCard.tsx:158</span> — export function ToolCard({ tool, thinking }: ToolCardProps)<br>
+<span style="font-family:'Geist Mono',monospace;font-size:11px;color:var(--color-accent);">web/src/components/ToolCard.tsx:5</span> — interface ToolCardProps<br>
+<span style="font-family:'Geist Mono',monospace;font-size:11px;color:var(--color-accent);">web/src/components/ChatView.tsx:42</span> — import { ToolCard } from "./ToolCard"</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="col">
+    <div class="col-header">B — v2 Fixed <span class="tag tag-v2">22px</span></div>
+    <div class="tool-card variant-v2">
+      <div class="tool-card-header">
+        <span class="status">✓</span>
+        <span class="name">grep</span>
+        <span class="args">pattern: ToolCard</span>
+        <span class="arrow">▾</span>
+      </div>
+      <div class="tool-card-body">
+        <div class="tool-card-body-inner">
+          <div class="plain-text-result">Found 3 matches in 2 files:<br><br>
+<span style="font-family:'Geist Mono',monospace;font-size:11px;color:var(--color-accent);">web/src/components/ToolCard.tsx:158</span> — export function ToolCard({ tool, thinking }: ToolCardProps)<br>
+<span style="font-family:'Geist Mono',monospace;font-size:11px;color:var(--color-accent);">web/src/components/ToolCard.tsx:5</span> — interface ToolCardProps<br>
+<span style="font-family:'Geist Mono',monospace;font-size:11px;color:var(--color-accent);">web/src/components/ChatView.tsx:42</span> — import { ToolCard } from "./ToolCard"</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="col">
+    <div class="col-header">C — Compact <span class="tag tag-compact">16px</span></div>
+    <div class="tool-card variant-compact">
+      <div class="tool-card-header">
+        <span class="status">✓</span>
+        <span class="name">grep</span>
+        <span class="args">pattern: ToolCard</span>
+        <span class="arrow">▾</span>
+      </div>
+      <div class="tool-card-body">
+        <div class="tool-card-body-inner">
+          <div class="plain-text-result">Found 3 matches in 2 files:<br><br>
+<span style="font-family:'Geist Mono',monospace;font-size:11px;color:var(--color-accent);">web/src/components/ToolCard.tsx:158</span> — export function ToolCard({ tool, thinking }: ToolCardProps)<br>
+<span style="font-family:'Geist Mono',monospace;font-size:11px;color:var(--color-accent);">web/src/components/ToolCard.tsx:5</span> — interface ToolCardProps<br>
+<span style="font-family:'Geist Mono',monospace;font-size:11px;color:var(--color-accent);">web/src/components/ChatView.tsx:42</span> — import { ToolCard } from "./ToolCard"</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="col">
+    <div class="col-header">D — Ultra (no border) <span class="tag tag-ultra">10px</span></div>
+    <div class="tool-card variant-ultra">
+      <div class="tool-card-header">
+        <span class="status">✓</span>
+        <span class="name">grep</span>
+        <span class="args">pattern: ToolCard</span>
+        <span class="arrow">▾</span>
+      </div>
+      <div class="tool-card-body">
+        <div class="tool-card-body-inner">
+          <div class="plain-text-result">Found 3 matches in 2 files:<br><br>
+<span style="font-family:'Geist Mono',monospace;font-size:11px;color:var(--color-accent);">web/src/components/ToolCard.tsx:158</span> — export function ToolCard({ tool, thinking }: ToolCardProps)<br>
+<span style="font-family:'Geist Mono',monospace;font-size:11px;color:var(--color-accent);">web/src/components/ToolCard.tsx:5</span> — interface ToolCardProps<br>
+<span style="font-family:'Geist Mono',monospace;font-size:11px;color:var(--color-accent);">web/src/components/ChatView.tsx:42</span> — import { ToolCard } from "./ToolCard"</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+</div>
+</div><!-- /text-results -->
+
+<div class="annotation" style="max-width:1100px;margin-top:28px;">
+  <strong>Variant notes:</strong><br>
+  <strong>A — Current (26px):</strong> The actual implementation today. <code>padding-top:10px</code> + <code>margin-top:2px</code> + Tailwind <code>p-3</code>(12px) on <code>&lt;pre&gt;</code>. Visible gap between border-top line and content.<br><br>
+  <strong>B — v2 Fixed (22px):</strong> The previous prototype's intended fix. <code>padding:8px 14px 10px</code> + explicit <code>pre { padding:10px 12px; margin:4px 0 }</code>. Slightly tighter but still has clear separation.<br><br>
+  <strong>C — Compact (16px):</strong> Further reduction. <code>padding:4px 14px 8px</code> + <code>margin-top:0</code> + <code>pre { padding:8px 10px; margin:2px 0 }</code>. Border-top kept but content hugs closer. Balanced — clear structure without wasted space.<br><br>
+  <strong>D — Ultra (10px):</strong> Removes <code>border-top</code> entirely. <code>padding:2px 14px 6px</code> + <code>pre { padding:6px 10px; margin:0 }</code>. Relies on background contrast (<code>--color-surface</code> vs <code>--color-bg</code> inside pre) for visual separation. Most compact — may feel too dense for some.
+</div>
+
+<script>
+  const btns = document.querySelectorAll('.toggle-btn');
+  const codeResults = document.getElementById('code-results');
+  const textResults = document.getElementById('text-results');
+  const modeLabel = document.getElementById('modeLabel');
+
+  btns.forEach(btn => {
+    btn.addEventListener('click', () => {
+      btns.forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+      const mode = btn.dataset.mode;
+      if (mode === 'code') {
+        codeResults.classList.remove('hidden');
+        textResults.classList.add('hidden');
+        modeLabel.textContent = 'Showing code-block results (list_files / bash)';
+      } else {
+        codeResults.classList.add('hidden');
+        textResults.classList.remove('hidden');
+        modeLabel.textContent = 'Showing plain-text results (read_file / grep)';
+      }
+    });
+  });
+</script>
+
+</body>
+</html>

--- a/docs/prototypes/builtin-tool-result-rendering-fix-v4.html
+++ b/docs/prototypes/builtin-tool-result-rendering-fix-v4.html
@@ -1,0 +1,340 @@
+<!DOCTYPE html>
+<!--
+  Change: toolcard-compact-spacing
+  Date: 2025-01-20
+  Descriptor: v4-root-cause-fix
+  Description: Shows why built-in ToolCard still has blank space after v3 fix.
+               Root cause: (1) .tool-card-body-inner lacks background:var(--color-bg),
+               (2) Markdown <pre> uses inline styles that CSS cannot override.
+               Side-by-side: current broken state vs fixed state.
+-->
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ToolCard Spacing v4 — Root Cause Fix</title>
+<style>
+  :root {
+    --color-bg: #f8f7f5;
+    --color-surface: #f3f2ef;
+    --color-surface-hover: #ebe9e5;
+    --color-border: #e6e4e0;
+    --color-text: #2d2a26;
+    --color-text-muted: #8a8580;
+    --color-accent: #ca8a04;
+    --color-accent-hover: #a07004;
+    --color-accent-bg: rgba(202, 138, 4, 0.12);
+    --color-success: #edf4ed;
+    --color-success-text: #347539;
+    --color-error: #fdebec;
+    --color-error-text: #9f2f2d;
+    --color-warning: #fbf3db;
+    --color-warning-text: #956400;
+  }
+
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+
+  body {
+    font-family: 'Geist Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    background: var(--color-bg);
+    color: var(--color-text);
+    padding: 32px 24px;
+    min-height: 100vh;
+  }
+
+  .page-header { max-width: 920px; margin: 0 auto 20px; }
+  .page-header h1 { font-size: 20px; font-weight: 700; letter-spacing: -0.01em; margin-bottom: 6px; }
+  .page-header p { font-size: 13px; color: var(--color-text-muted); line-height: 1.5; }
+
+  .grid { max-width: 920px; margin: 0 auto; display: grid; grid-template-columns: 1fr 1fr; gap: 24px; }
+  .col-header { font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em; color: var(--color-text-muted); margin-bottom: 10px; display: flex; align-items: center; gap: 8px; }
+  .tag { font-size: 9px; padding: 2px 7px; border-radius: 10px; font-weight: 700; }
+  .tag-broken { background: var(--color-error); color: var(--color-error-text); }
+  .tag-fixed { background: var(--color-success); color: var(--color-success-text); }
+
+  /* ── Shared card structure ── */
+  .tool-card { background: var(--color-surface); border: 1px solid var(--color-border); border-radius: 6px; overflow: hidden; margin-bottom: 14px; }
+  .tool-card-header { display: flex; align-items: center; gap: 10px; padding: 8px 14px; cursor: pointer; user-select: none; }
+  .tool-card-header .status { font-size: 11px; width: 18px; height: 18px; display: flex; align-items: center; justify-content: center; border-radius: 4px; font-weight: 700; flex-shrink: 0; background: var(--color-success); color: var(--color-success-text); }
+  .tool-card-header .name { font-family: 'Geist Mono', 'JetBrains Mono', monospace; font-size: 11px; font-weight: 600; color: var(--color-accent); }
+  .tool-card-header .args { font-size: 11px; color: var(--color-text-muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 1; }
+  .tool-card-header .arrow { font-size: 9px; color: var(--color-text-muted); opacity: 0.4; flex-shrink: 0; transform: rotate(180deg); }
+  .tool-card-body { overflow: hidden; }
+
+  /* ════════ LEFT: Current (broken) — simulates actual rendered state ════════ */
+  /* .tool-card-body-inner has NO background → inherits --color-surface */
+  .broken .tool-card-body-inner {
+    padding: 2px 14px 6px;
+    margin-top: 0;
+    max-height: 400px;
+    overflow-y: auto;
+    /* NO background — inherits --color-surface from .tool-card */
+  }
+  /* <pre> keeps inline styles: border, borderRadius, backgroundColor — CSS can't override */
+  .broken .md-pre {
+    background: var(--color-bg);           /* ← inline style, CSS can't override */
+    border: 1px solid var(--color-border);  /* ← inline style, CSS can't override */
+    border-radius: 8px;                     /* ← inline style, CSS can't override */
+    padding: 6px 10px;                      /* ← CSS override of p-3 works */
+    margin: 0;                              /* ← CSS override of my-1 works */
+    overflow-x: auto;
+    font-family: 'Geist Mono', 'JetBrains Mono', monospace;
+    font-size: 11px;
+    line-height: 1.55;
+    color: var(--color-text);
+    white-space: pre;
+  }
+  .broken .md-pre .code-lang { display: block; font-size: 9px; color: var(--color-text-muted); text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 4px; }
+
+  /* ════════ RIGHT: Fixed — background + no border ════════ */
+  .fixed .tool-card-body-inner {
+    padding: 2px 14px 6px;
+    margin-top: 0;
+    max-height: 400px;
+    overflow-y: auto;
+    background: var(--color-bg);            /* ← FIX #1: match pre background */
+  }
+  .fixed .md-pre {
+    background: var(--color-bg);
+    border: none;                            /* ← FIX #2: no border (moved from inline to class) */
+    border-radius: 4px;
+    padding: 6px 10px;
+    margin: 0;
+    overflow-x: auto;
+    font-family: 'Geist Mono', 'JetBrains Mono', monospace;
+    font-size: 11px;
+    line-height: 1.55;
+    color: var(--color-text);
+    white-space: pre;
+  }
+  .fixed .md-pre .code-lang { display: block; font-size: 9px; color: var(--color-text-muted); text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 4px; }
+
+  /* ── MCP comparison (already works) ── */
+  .mcp-card { background: var(--color-surface); border: 1px solid var(--color-border); border-left: 2px solid var(--color-accent); border-radius: 6px; overflow: hidden; margin-bottom: 14px; }
+  .mcp-badge { display: inline-block; font-family: 'Geist Mono', monospace; font-size: 8px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em; padding: 1px 5px; border-radius: 3px; background: var(--color-accent-bg); color: var(--color-accent); flex-shrink: 0; }
+  .mcp-raw-block {
+    padding: 2px 14px 6px;
+    max-height: 280px;
+    overflow-y: auto;
+    background: var(--color-bg);            /* ← MCP already has this! */
+  }
+  .mcp-raw-block .md-pre {
+    background: var(--color-bg);
+    border: none;
+    border-radius: 4px;
+    padding: 6px 10px;
+    margin: 0;
+    overflow-x: auto;
+    font-family: 'Geist Mono', 'JetBrains Mono', monospace;
+    font-size: 11px;
+    line-height: 1.55;
+    color: var(--color-text);
+    white-space: pre;
+  }
+
+  /* ── Annotations ── */
+  .annotation { max-width: 920px; margin: 12px auto 0; padding: 10px 14px; border-radius: 6px; font-size: 11px; line-height: 1.5; display: flex; align-items: flex-start; gap: 8px; }
+  .annotation.warn { background: var(--color-warning); color: var(--color-warning-text); }
+  .annotation.ok { background: var(--color-success); color: var(--color-success-text); }
+  .annotation .ann-icon { flex-shrink: 0; font-weight: 700; }
+  .annotation code { font-family: 'Geist Mono', monospace; font-size: 10px; }
+
+  .section-label { max-width: 920px; margin: 28px auto 10px; font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em; color: var(--color-text-muted); padding-bottom: 8px; border-bottom: 1px solid var(--color-border); }
+  .section-label:first-of-type { margin-top: 0; }
+
+  .root-cause { max-width: 920px; margin: 20px auto; padding: 16px; background: var(--color-surface); border: 1px solid var(--color-border); border-radius: 8px; font-size: 12px; line-height: 1.6; color: var(--color-text); }
+  .root-cause h3 { font-size: 13px; font-weight: 700; margin-bottom: 10px; }
+  .root-cause ul { padding-left: 18px; margin-top: 6px; }
+  .root-cause li { margin-bottom: 4px; }
+  .root-cause code { font-family: 'Geist Mono', monospace; font-size: 11px; background: var(--color-accent-bg); color: var(--color-accent); padding: 1px 4px; border-radius: 3px; }
+</style>
+</head>
+<body>
+
+<div class="page-header">
+  <h1>ToolCard Spacing v4 — Root Cause Fix</h1>
+  <p>Why built-in tools still show blank space after v3 changes. Two root causes identified and fixed.</p>
+</div>
+
+<div class="root-cause">
+  <h3>Root Cause Analysis</h3>
+  <strong>Why MCP tools look fine but built-in tools don't:</strong>
+  <ul>
+    <li><strong>Cause 1 — Missing background:</strong> <code>.mcp-raw-block</code> has <code>background: var(--color-bg)</code> but <code>.tool-card-body-inner</code> does NOT. The 2px container padding is invisible on MCP (same color as <code>&lt;pre&gt;</code> background) but visible on built-in tools (<code>--color-surface</code> vs <code>--color-bg</code> contrast).</li>
+    <li><strong>Cause 2 — Inline styles on <code>&lt;pre&gt;</code>:</strong> The Markdown component renders <code>&lt;pre&gt;</code> with <code>style={{ border, borderRadius, backgroundColor }}</code>. Inline styles (specificity 1,0,0,0) cannot be overridden by CSS selectors like <code>.tool-card-body-inner pre</code> (specificity 0,2,0). So <code>border: none</code> and <code>border-radius: 4px</code> from our CSS never take effect — the <code>&lt;pre&gt;</code> keeps its full border and 8px radius.</li>
+  </ul>
+  <strong>Fix:</strong> (1) Add <code>background: var(--color-bg)</code> to <code>.tool-card-body-inner</code>. (2) Move Markdown <code>&lt;pre&gt;</code> inline styles to a CSS class so scoped overrides work.
+</div>
+
+<div class="section-label">Built-in tool — list_files (JSON result)</div>
+<div class="grid">
+
+  <!-- LEFT: Current broken state -->
+  <div>
+    <div class="col-header">Current (broken) <span class="tag tag-broken">GAP VISIBLE</span></div>
+    <div class="tool-card broken">
+      <div class="tool-card-header">
+        <span class="status">✓</span>
+        <span class="name">list_files</span>
+        <span class="args">path: src/ui</span>
+        <span class="arrow">▾</span>
+      </div>
+      <div class="tool-card-body">
+        <div class="tool-card-body-inner">
+          <div class="md-pre"><span class="code-lang">json</span>[
+  { "path": "src/ui/backend.ts", "isDir": false, "name": "backend.ts", "depth": 0 },
+  { "path": "src/ui/conversation.ts", "isDir": false, "name": "conversation.ts", "depth": 0 },
+  { "path": "src/ui/mdx", "isDir": true, "name": "mdx", "depth": 0 }
+]</div>
+        </div>
+      </div>
+    </div>
+    <div class="annotation warn">
+      <span class="ann-icon">⚠</span>
+      <span>2px gap is <code>--color-surface</code> (visible contrast against <code>&lt;pre&gt;</code>'s <code>--color-bg</code>). <code>&lt;pre&gt;</code> keeps inline <code>border: 1px solid</code> and <code>border-radius: 8px</code> — CSS <code>border: none</code> has no effect on inline styles.</span>
+    </div>
+  </div>
+
+  <!-- RIGHT: Fixed state -->
+  <div>
+    <div class="col-header">Fixed <span class="tag tag-fixed">TIGHT</span></div>
+    <div class="tool-card fixed">
+      <div class="tool-card-header">
+        <span class="status">✓</span>
+        <span class="name">list_files</span>
+        <span class="args">path: src/ui</span>
+        <span class="arrow">▾</span>
+      </div>
+      <div class="tool-card-body">
+        <div class="tool-card-body-inner">
+          <div class="md-pre"><span class="code-lang">json</span>[
+  { "path": "src/ui/backend.ts", "isDir": false, "name": "backend.ts", "depth": 0 },
+  { "path": "src/ui/conversation.ts", "isDir": false, "name": "conversation.ts", "depth": 0 },
+  { "path": "src/ui/mdx", "isDir": true, "name": "mdx", "depth": 0 }
+]</div>
+        </div>
+      </div>
+    </div>
+    <div class="annotation ok">
+      <span class="ann-icon">✓</span>
+      <span>Container has <code>background: var(--color-bg)</code> — 2px gap invisible. <code>&lt;pre&gt;</code> inline styles moved to CSS class — <code>border: none</code>, <code>border-radius: 4px</code> now effective. Identical visual tightness to MCP tools.</span>
+    </div>
+  </div>
+
+</div>
+
+<div class="section-label">Built-in tool — bash (command output)</div>
+<div class="grid">
+
+  <div>
+    <div class="col-header">Current (broken) <span class="tag tag-broken">GAP VISIBLE</span></div>
+    <div class="tool-card broken">
+      <div class="tool-card-header">
+        <span class="status">✓</span>
+        <span class="name">bash</span>
+        <span class="args">npm test</span>
+        <span class="arrow">▾</span>
+      </div>
+      <div class="tool-card-body">
+        <div class="tool-card-body-inner">
+          <div class="md-pre"><span class="code-lang">sh</span>PASS  src/ui/shared/reducer.test.ts
+PASS  src/utils/image.test.ts
+PASS  src/session/store.test.ts
+PASS  src/permissions/fuzzy.test.ts
+
+Tests:       5 passed, 5 total
+Time:        3.2s</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div>
+    <div class="col-header">Fixed <span class="tag tag-fixed">TIGHT</span></div>
+    <div class="tool-card fixed">
+      <div class="tool-card-header">
+        <span class="status">✓</span>
+        <span class="name">bash</span>
+        <span class="args">npm test</span>
+        <span class="arrow">▾</span>
+      </div>
+      <div class="tool-card-body">
+        <div class="tool-card-body-inner">
+          <div class="md-pre"><span class="code-lang">sh</span>PASS  src/ui/shared/reducer.test.ts
+PASS  src/utils/image.test.ts
+PASS  src/session/store.test.ts
+PASS  src/permissions/fuzzy.test.ts
+
+Tests:       5 passed, 5 total
+Time:        3.2s</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+</div>
+
+<div class="section-label">MCP tool — already works (for comparison)</div>
+<div class="grid">
+
+  <div>
+    <div class="col-header">MCP raw block <span class="tag tag-fixed">ALREADY FINE</span></div>
+    <div class="mcp-card">
+      <div class="tool-card-header">
+        <span class="status">✓</span>
+        <span class="name">mcp__github__get_file</span>
+        <span class="mcp-badge">MCP</span>
+        <span class="args">repo: dscode, path: README.md</span>
+        <span class="arrow">▾</span>
+      </div>
+      <div class="tool-card-body">
+        <div class="mcp-raw-block">
+          <div class="md-pre"><span class="code-lang">md</span># DSCode
+
+A digital studio for content-driven creation.
+
+## Features
+
+- Writing — AI-assisted editing
+- Code — Full development environment</div>
+        </div>
+      </div>
+    </div>
+    <div class="annotation ok">
+      <span class="ann-icon">✓</span>
+      <span><code>.mcp-raw-block</code> already has <code>background: var(--color-bg)</code>. No visible gap. This is the target look for built-in tools.</span>
+    </div>
+  </div>
+
+  <div>
+    <div class="col-header">Built-in (fixed) — now matches MCP <span class="tag tag-fixed">MATCHES</span></div>
+    <div class="tool-card fixed">
+      <div class="tool-card-header">
+        <span class="status">✓</span>
+        <span class="name">read_file</span>
+        <span class="args">path: README.md</span>
+        <span class="arrow">▾</span>
+      </div>
+      <div class="tool-card-body">
+        <div class="tool-card-body-inner">
+          <div class="md-pre"><span class="code-lang">md</span># DSCode
+
+A digital studio for content-driven creation.
+
+## Features
+
+- Writing — AI-assisted editing
+- Code — Full development environment</div>
+        </div>
+      </div>
+    </div>
+    <div class="annotation ok">
+      <span class="ann-icon">✓</span>
+      <span>After fix: built-in tool ToolCard visually identical to MCP raw block. Same background, same tight spacing, no border on <code>&lt;pre&gt;</code>.</span>
+    </div>
+  </div>
+
+</div>
+
+</body>
+</html>

--- a/docs/prototypes/builtin-tool-result-rendering-fix-v5.html
+++ b/docs/prototypes/builtin-tool-result-rendering-fix-v5.html
@@ -1,0 +1,348 @@
+<!DOCTYPE html>
+<!--
+  Change: toolcard-compact-spacing
+  Date: 2025-01-20
+  Descriptor: v5-cascade-layer-fix
+  Description: TRUE root cause — CSS @layer components cannot override @layer utilities.
+               .tool-card-body-inner pre { padding: 6px } is in @layer components,
+               but .p-3 { padding: 12px } is in @layer utilities. Utilities always wins.
+               The scoped override NEVER worked. <pre> keeps 12px padding + 4px margin.
+               
+               Fix: move the override OUT of @layer components to unlayered CSS.
+               
+               Also shows why built-in tools have the gap but MCP tools don't:
+               built-in results are wrapped in code fences → <pre> with p-3 (12px) + my-1 (4px)
+               MCP plain text results → <p> with 0 margin (Tailwind preflight).
+-->
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ToolCard Spacing v5 — Cascade Layer Root Cause</title>
+<style>
+  :root {
+    --color-bg: #f8f7f5;
+    --color-surface: #f3f2ef;
+    --color-surface-hover: #ebe9e5;
+    --color-border: #e6e4e0;
+    --color-text: #2d2a26;
+    --color-text-muted: #8a8580;
+    --color-accent: #ca8a04;
+    --color-accent-bg: rgba(202, 138, 4, 0.12);
+    --color-success: #edf4ed;
+    --color-success-text: #347539;
+    --color-error: #fdebec;
+    --color-error-text: #9f2f2d;
+    --color-warning: #fbf3db;
+    --color-warning-text: #956400;
+  }
+
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+
+  body {
+    font-family: 'Geist Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    background: var(--color-bg);
+    color: var(--color-text);
+    padding: 32px 24px;
+    min-height: 100vh;
+  }
+
+  .page-header { max-width: 920px; margin: 0 auto 20px; }
+  .page-header h1 { font-size: 20px; font-weight: 700; letter-spacing: -0.01em; margin-bottom: 6px; }
+  .page-header p { font-size: 13px; color: var(--color-text-muted); line-height: 1.5; }
+
+  .root-cause { max-width: 920px; margin: 20px auto; padding: 16px; background: var(--color-surface); border: 1px solid var(--color-border); border-radius: 8px; font-size: 12px; line-height: 1.6; color: var(--color-text); }
+  .root-cause h3 { font-size: 13px; font-weight: 700; margin-bottom: 10px; }
+  .root-cause code { font-family: 'Geist Mono', monospace; font-size: 11px; background: var(--color-accent-bg); color: var(--color-accent); padding: 1px 4px; border-radius: 3px; }
+  .root-cause .layer-stack { font-family: 'Geist Mono', monospace; font-size: 11px; background: var(--color-bg); border: 1px solid var(--color-border); border-radius: 6px; padding: 12px; margin: 10px 0; line-height: 1.7; }
+  .root-cause .layer-stack .winner { color: var(--color-success-text); font-weight: 700; }
+  .root-cause .layer-stack .loser { color: var(--color-error-text); text-decoration: line-through; }
+
+  .grid { max-width: 920px; margin: 0 auto; display: grid; grid-template-columns: 1fr 1fr; gap: 24px; }
+  .col-header { font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em; color: var(--color-text-muted); margin-bottom: 10px; display: flex; align-items: center; gap: 8px; }
+  .tag { font-size: 9px; padding: 2px 7px; border-radius: 10px; font-weight: 700; }
+  .tag-broken { background: var(--color-error); color: var(--color-error-text); }
+  .tag-fixed { background: var(--color-success); color: var(--color-success-text); }
+
+  /* ── Shared card structure ── */
+  .tool-card { background: var(--color-surface); border: 1px solid var(--color-border); border-radius: 6px; overflow: hidden; margin-bottom: 14px; }
+  .tool-card-header { display: flex; align-items: center; gap: 10px; padding: 8px 14px; }
+  .tool-card-header .status { font-size: 11px; width: 18px; height: 18px; display: flex; align-items: center; justify-content: center; border-radius: 4px; font-weight: 700; flex-shrink: 0; background: var(--color-success); color: var(--color-success-text); }
+  .tool-card-header .name { font-family: 'Geist Mono', 'JetBrains Mono', monospace; font-size: 11px; font-weight: 600; color: var(--color-accent); }
+  .tool-card-header .args { font-size: 11px; color: var(--color-text-muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 1; }
+  .tool-card-header .arrow { font-size: 9px; color: var(--color-text-muted); opacity: 0.4; flex-shrink: 0; transform: rotate(180deg); }
+
+  /* ════════ LEFT: Broken — simulates @layer components (override never works) ════════ */
+  .broken .tool-card-body-inner {
+    padding: 2px 14px 6px;
+    margin-top: 0;
+    /* NO background */
+  }
+  /* Simulates: .p-3 wins over .tool-card-body-inner pre because @layer utilities > @layer components */
+  .broken .md-pre {
+    background: var(--color-bg);
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    padding: 12px;          /* ← p-3 WINS (12px, not 6px) */
+    margin: 4px 0;          /* ← my-1 WINS (4px, not 0) */
+    overflow-x: auto;
+    font-family: 'Geist Mono', 'JetBrains Mono', monospace;
+    font-size: 11px;
+    line-height: 1.55;
+    color: var(--color-text);
+    white-space: pre;
+  }
+
+  /* ════════ RIGHT: Fixed — unlayered CSS overrides Tailwind utilities ════════ */
+  .fixed .tool-card-body-inner {
+    padding: 2px 14px 6px;
+    margin-top: 0;
+    background: var(--color-bg);
+  }
+  /* Simulates: override moved OUT of @layer components → unlayered CSS beats all @layer rules */
+  .fixed .md-pre {
+    background: var(--color-bg);
+    border: none;
+    border-radius: 4px;
+    padding: 6px 10px;      /* ← override WORKS (unlayered > @layer utilities) */
+    margin: 0;              /* ← override WORKS */
+    overflow-x: auto;
+    font-family: 'Geist Mono', 'JetBrains Mono', monospace;
+    font-size: 11px;
+    line-height: 1.55;
+    color: var(--color-text);
+    white-space: pre;
+  }
+
+  /* ── MCP comparison (plain text, no <pre>) ── */
+  .mcp-card { background: var(--color-surface); border: 1px solid var(--color-border); border-left: 2px solid var(--color-accent); border-radius: 6px; overflow: hidden; margin-bottom: 14px; }
+  .mcp-badge { display: inline-block; font-family: 'Geist Mono', monospace; font-size: 8px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em; padding: 1px 5px; border-radius: 3px; background: var(--color-accent-bg); color: var(--color-accent); flex-shrink: 0; }
+  .mcp-raw-block {
+    padding: 2px 14px 6px;
+    background: var(--color-bg);
+  }
+  .mcp-raw-block .md-p {
+    font-family: 'Geist Sans', sans-serif;
+    font-size: 12px;
+    line-height: 1.6;
+    color: var(--color-text);
+    margin: 0;              /* ← <p> margin is 0 (Tailwind preflight) */
+  }
+
+  /* ── Measurement annotations ── */
+  .gap-measure {
+    font-family: 'Geist Mono', monospace;
+    font-size: 10px;
+    color: var(--color-text-muted);
+    padding: 6px 10px;
+    background: var(--color-warning);
+    color: var(--color-warning-text);
+    border-radius: 4px;
+    margin-bottom: 8px;
+    line-height: 1.5;
+  }
+  .gap-measure strong { color: var(--color-error-text); }
+
+  .annotation { max-width: 920px; margin: 12px auto 0; padding: 10px 14px; border-radius: 6px; font-size: 11px; line-height: 1.5; }
+  .annotation.warn { background: var(--color-warning); color: var(--color-warning-text); }
+  .annotation.ok { background: var(--color-success); color: var(--color-success-text); }
+  .annotation code { font-family: 'Geist Mono', monospace; font-size: 10px; }
+
+  .section-label { max-width: 920px; margin: 28px auto 10px; font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em; color: var(--color-text-muted); padding-bottom: 8px; border-bottom: 1px solid var(--color-border); }
+  .section-label:first-of-type { margin-top: 0; }
+</style>
+</head>
+<body>
+
+<div class="page-header">
+  <h1>ToolCard Spacing v5 — True Root Cause: CSS Cascade Layers</h1>
+  <p>The v3 scoped CSS override never worked. Here's why — and the real fix.</p>
+</div>
+
+<div class="root-cause">
+  <h3>True Root Cause: @layer components cannot override @layer utilities</h3>
+  <p>The scoped CSS rule <code>.tool-card-body-inner pre { padding: 6px 10px; margin: 0 }</code> is inside <code>@layer components</code> in <code>index.css</code>. But the Markdown component's <code>&lt;pre&gt;</code> uses Tailwind classes <code>p-3</code> (12px) and <code>my-1</code> (4px), which live in <code>@layer utilities</code>.</p>
+  <p><strong>CSS cascade layers: <code>utilities</code> always beats <code>components</code>, regardless of specificity.</strong></p>
+  
+  <div class="layer-stack">
+    @layer base      { /* preflight resets */ }
+    @layer components { .tool-card-body-inner pre { padding: 6px 10px } }  <span class="loser">← LOSES</span>
+    @layer utilities  { .p-3 { padding: 12px }  .my-1 { margin: 4px } }    <span class="winner">← WINS</span>
+    
+    Result: &lt;pre&gt; padding = 12px (not 6px), margin = 4px (not 0)
+  </div>
+
+  <p><strong>Why built-in tools have the gap but MCP tools don't:</strong></p>
+  <ul style="padding-left: 18px; margin-top: 6px;">
+    <li>Built-in tools (<code>bash</code>, <code>read_file</code>, <code>grep</code>): <code>formatToolResultForUI</code> wraps result in code fence → renders <code>&lt;pre&gt;</code> with <code>p-3</code> (12px) + <code>my-1</code> (4px) = <strong>16px gap</strong></li>
+    <li>MCP tools (plain text): no code fence → renders <code>&lt;p&gt;</code> with 0 margin (Tailwind preflight) = <strong>0px gap</strong></li>
+  </ul>
+
+  <p style="margin-top: 10px;"><strong>Fix:</strong> Move <code>.tool-card-body-inner pre</code> rule <strong>out of</strong> <code>@layer components</code> to unlayered CSS. Unlayered CSS beats all <code>@layer</code> rules. Also move inline styles on <code>&lt;pre&gt;</code> to a CSS class for border/radius override.</p>
+</div>
+
+<div class="section-label">Built-in tool — bash (code fence → &lt;pre&gt; with p-3 + my-1)</div>
+<div class="grid">
+
+  <div>
+    <div class="col-header">Broken (current) <span class="tag tag-broken">19px gap</span></div>
+    <div class="gap-measure">
+      2px (container)<br>
+      + 4px (pre my-1 — <strong>NOT overridden</strong>)<br>
+      + 1px (pre border — inline style)<br>
+      + 12px (pre p-3 — <strong>NOT overridden</strong>)<br>
+      = <strong>19px total</strong>
+    </div>
+    <div class="tool-card broken">
+      <div class="tool-card-header">
+        <span class="status">✓</span>
+        <span class="name">bash</span>
+        <span class="args">npm test</span>
+        <span class="arrow">▾</span>
+      </div>
+      <div class="tool-card-body-inner">
+        <div class="md-pre">PASS  src/ui/shared/reducer.test.ts
+PASS  src/utils/image.test.ts
+PASS  src/session/store.test.ts
+PASS  src/permissions/fuzzy.test.ts
+
+Tests:       5 passed, 5 total
+Time:        3.2s</div>
+      </div>
+    </div>
+  </div>
+
+  <div>
+    <div class="col-header">Fixed (unlayered) <span class="tag tag-fixed">8px gap</span></div>
+    <div class="gap-measure">
+      2px (container)<br>
+      + 0px (pre margin — override works)<br>
+      + 0px (pre border — removed via class)<br>
+      + 6px (pre padding — override works)<br>
+      = <strong>8px total</strong>
+    </div>
+    <div class="tool-card fixed">
+      <div class="tool-card-header">
+        <span class="status">✓</span>
+        <span class="name">bash</span>
+        <span class="args">npm test</span>
+        <span class="arrow">▾</span>
+      </div>
+      <div class="tool-card-body-inner">
+        <div class="md-pre">PASS  src/ui/shared/reducer.test.ts
+PASS  src/utils/image.test.ts
+PASS  src/session/store.test.ts
+PASS  src/permissions/fuzzy.test.ts
+
+Tests:       5 passed, 5 total
+Time:        3.2s</div>
+      </div>
+    </div>
+  </div>
+
+</div>
+
+<div class="section-label">Built-in tool — list_files (JSON in code fence)</div>
+<div class="grid">
+
+  <div>
+    <div class="col-header">Broken (current) <span class="tag tag-broken">19px gap</span></div>
+    <div class="tool-card broken">
+      <div class="tool-card-header">
+        <span class="status">✓</span>
+        <span class="name">list_files</span>
+        <span class="args">path: src/ui</span>
+        <span class="arrow">▾</span>
+      </div>
+      <div class="tool-card-body-inner">
+        <div class="md-pre">[
+  { "path": "src/ui/backend.ts", "isDir": false, "name": "backend.ts", "depth": 0 },
+  { "path": "src/ui/conversation.ts", "isDir": false, "name": "conversation.ts", "depth": 0 },
+  { "path": "src/ui/mdx", "isDir": true, "name": "mdx", "depth": 0 }
+]</div>
+      </div>
+    </div>
+  </div>
+
+  <div>
+    <div class="col-header">Fixed (unlayered) <span class="tag tag-fixed">8px gap</span></div>
+    <div class="tool-card fixed">
+      <div class="tool-card-header">
+        <span class="status">✓</span>
+        <span class="name">list_files</span>
+        <span class="args">path: src/ui</span>
+        <span class="arrow">▾</span>
+      </div>
+      <div class="tool-card-body-inner">
+        <div class="md-pre">[
+  { "path": "src/ui/backend.ts", "isDir": false, "name": "backend.ts", "depth": 0 },
+  { "path": "src/ui/conversation.ts", "isDir": false, "name": "conversation.ts", "depth": 0 },
+  { "path": "src/ui/mdx", "isDir": true, "name": "mdx", "depth": 0 }
+]</div>
+      </div>
+    </div>
+  </div>
+
+</div>
+
+<div class="section-label">MCP tool — plain text (no &lt;pre&gt;, no gap — for comparison)</div>
+<div class="grid">
+
+  <div>
+    <div class="col-header">MCP raw block <span class="tag tag-fixed">2px gap</span></div>
+    <div class="gap-measure">
+      2px (container)<br>
+      + 0px (&lt;p&gt; margin = 0, Tailwind preflight)<br>
+      = <strong>2px total</strong>
+    </div>
+    <div class="mcp-card">
+      <div class="tool-card-header">
+        <span class="status">✓</span>
+        <span class="name">mcp__github__get_file</span>
+        <span class="mcp-badge">MCP</span>
+        <span class="args">repo: dscode, path: README.md</span>
+        <span class="arrow">▾</span>
+      </div>
+      <div class="mcp-raw-block">
+        <div class="md-p">Retrieved file content from GitHub. The file contains project documentation including installation instructions, usage examples, and configuration details.</div>
+      </div>
+    </div>
+  </div>
+
+  <div>
+    <div class="col-header">Built-in (fixed) — now matches <span class="tag tag-fixed">8px gap</span></div>
+    <div class="gap-measure">
+      2px (container)<br>
+      + 0px (pre margin — override works)<br>
+      + 0px (pre border — removed via class)<br>
+      + 6px (pre padding — override works)<br>
+      = <strong>8px total</strong>
+    </div>
+    <div class="tool-card fixed">
+      <div class="tool-card-header">
+        <span class="status">✓</span>
+        <span class="name">read_file</span>
+        <span class="args">path: README.md</span>
+        <span class="arrow">▾</span>
+      </div>
+      <div class="tool-card-body-inner">
+        <div class="md-pre"># DSCode
+
+A digital studio for content-driven creation.
+
+## Features
+
+- Writing — AI-assisted editing
+- Code — Full development environment</div>
+      </div>
+    </div>
+  </div>
+
+</div>
+
+<div class="annotation ok" style="max-width:920px;margin-top:20px;">
+  <strong>Fix summary:</strong> Move <code>.tool-card-body-inner pre</code> out of <code>@layer components</code> to unlayered CSS. Move Markdown <code>&lt;pre&gt;</code> inline styles (<code>border</code>, <code>borderRadius</code>, <code>backgroundColor</code>) to a CSS class <code>md-pre-base</code> so scoped overrides work. Add <code>background: var(--color-bg)</code> to <code>.tool-card-body-inner</code> for visual consistency with <code>.mcp-raw-block</code>.
+</div>
+
+</body>
+</html>

--- a/docs/prototypes/builtin-tool-result-rendering-fix.html
+++ b/docs/prototypes/builtin-tool-result-rendering-fix.html
@@ -1,0 +1,906 @@
+<!DOCTYPE html>
+<!--
+  Change: builtin-tool-result-rendering-fix
+  Date: 2025-01-20
+  Description: Prototype comparing current (broken) vs proposed (fixed) rendering
+               of built-in tool results in the Web UI ToolCard component.
+-->
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Built-in Tool Result Rendering — Before vs After</title>
+<style>
+  :root {
+    --color-bg: #f8f7f5;
+    --color-surface: #f3f2ef;
+    --color-surface-hover: #ebe9e5;
+    --color-border: #e6e4e0;
+    --color-text: #2d2a26;
+    --color-text-muted: #8a8580;
+    --color-accent: #ca8a04;
+    --color-accent-hover: #a07004;
+    --color-accent-bg: rgba(202, 138, 4, 0.12);
+    --color-success: #edf4ed;
+    --color-success-text: #347539;
+    --color-error: #fdebec;
+    --color-error-text: #9f2f2d;
+    --color-warning: #fbf3db;
+    --color-warning-text: #956400;
+  }
+
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+
+  body {
+    font-family: 'Geist Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    background: var(--color-bg);
+    color: var(--color-text);
+    padding: 32px 24px;
+    min-height: 100vh;
+  }
+
+  /* ── Page Header ── */
+  .page-header {
+    max-width: 920px;
+    margin: 0 auto 28px;
+  }
+  .page-header h1 {
+    font-size: 20px;
+    font-weight: 700;
+    letter-spacing: -0.01em;
+    margin-bottom: 6px;
+  }
+  .page-header p {
+    font-size: 13px;
+    color: var(--color-text-muted);
+    line-height: 1.5;
+  }
+
+  /* ── Toggle Bar ── */
+  .toggle-bar {
+    max-width: 920px;
+    margin: 0 auto 24px;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+  }
+  .toggle-group {
+    display: inline-flex;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    padding: 3px;
+  }
+  .toggle-btn {
+    padding: 7px 18px;
+    font-size: 12px;
+    font-weight: 600;
+    border: none;
+    background: transparent;
+    color: var(--color-text-muted);
+    cursor: pointer;
+    border-radius: 6px;
+    transition: all 0.15s;
+    font-family: inherit;
+  }
+  .toggle-btn.active {
+    background: var(--color-accent);
+    color: #fff;
+  }
+  .toggle-btn:not(.active):hover {
+    background: var(--color-surface-hover);
+    color: var(--color-text);
+  }
+  .toggle-label {
+    font-size: 11px;
+    color: var(--color-text-muted);
+    font-family: 'Geist Mono', monospace;
+  }
+
+  /* ── Side-by-side ── */
+  .comparison {
+    max-width: 920px;
+    margin: 0 auto;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 20px;
+  }
+  .comparison.single {
+    grid-template-columns: 1fr;
+  }
+  .col-header {
+    font-size: 11px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--color-text-muted);
+    margin-bottom: 10px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .col-header .tag {
+    font-size: 9px;
+    padding: 2px 7px;
+    border-radius: 10px;
+    font-weight: 700;
+  }
+  .tag-broken {
+    background: var(--color-error);
+    color: var(--color-error-text);
+  }
+  .tag-fixed {
+    background: var(--color-success);
+    color: var(--color-success-text);
+  }
+
+  /* ── Tool Card (matches web/src/index.css) ── */
+  .tool-card {
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    overflow: hidden;
+    margin-bottom: 14px;
+  }
+  .tool-card.mcp {
+    border-left: 2px solid var(--color-accent);
+  }
+
+  .tool-card-header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 14px;
+    cursor: pointer;
+    user-select: none;
+  }
+  .tool-card-header .status {
+    font-size: 11px;
+    width: 18px;
+    height: 18px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 4px;
+    font-weight: 700;
+    flex-shrink: 0;
+  }
+  .tool-card-header .status.ok {
+    background: var(--color-success);
+    color: var(--color-success-text);
+  }
+  .tool-card-header .status.err {
+    background: var(--color-error);
+    color: var(--color-error-text);
+  }
+  .tool-card-header .name {
+    font-family: 'Geist Mono', 'JetBrains Mono', monospace;
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--color-accent);
+  }
+  .tool-card-header .args {
+    font-size: 11px;
+    color: var(--color-text-muted);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    flex: 1;
+  }
+  .tool-card-header .arrow {
+    font-size: 9px;
+    color: var(--color-text-muted);
+    opacity: 0.4;
+    flex-shrink: 0;
+    transition: transform 0.3s;
+  }
+  .tool-card.open .tool-card-header .arrow {
+    transform: rotate(180deg);
+  }
+  .mcp-badge {
+    display: inline-block;
+    font-family: 'Geist Mono', monospace;
+    font-size: 8px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    padding: 1px 5px;
+    border-radius: 3px;
+    background: var(--color-accent-bg);
+    color: var(--color-accent);
+    flex-shrink: 0;
+  }
+
+  .tool-card-body {
+    max-height: 0;
+    overflow: hidden;
+    transition: max-height 0.3s ease;
+  }
+  .tool-card.open .tool-card-body {
+    max-height: 600px;
+  }
+
+  /* ── BEFORE: broken line-by-line rendering ── */
+  .tool-card-body-inner-broken {
+    padding: 0 14px 12px;
+    font-family: 'Geist Mono', 'JetBrains Mono', monospace;
+    font-size: 11px;
+    line-height: 1.5;
+    color: var(--color-text-muted);
+    border-top: 1px solid var(--color-border);
+    padding-top: 10px;
+    margin-top: 2px;
+    max-height: 200px;
+    overflow-y: auto;
+    white-space: pre-wrap;
+    word-break: break-all;
+  }
+  .tool-card-body-inner-broken .md-line {
+    display: block;
+  }
+  .tool-card-body-inner-broken .md-line.empty {
+    display: block;
+    height: 1em;
+  }
+  /* Simulates what ReactMarkdown does when it gets a single line "```sh" — renders as text */
+  .broken-fence {
+    color: var(--color-text-muted);
+  }
+
+  /* ── AFTER: fixed whole-markdown rendering ── */
+  .tool-card-body-inner-fixed {
+    padding: 0 14px 12px;
+    border-top: 1px solid var(--color-border);
+    padding-top: 10px;
+    margin-top: 2px;
+    max-height: 320px;
+    overflow-y: auto;
+  }
+  .tool-card-body-inner-fixed .md-content {
+    font-size: 12px;
+    line-height: 1.6;
+    color: var(--color-text);
+  }
+  .tool-card-body-inner-fixed .md-content p {
+    margin-bottom: 6px;
+  }
+  .tool-card-body-inner-fixed .md-content p:last-child {
+    margin-bottom: 0;
+  }
+  .tool-card-body-inner-fixed .code-block {
+    background: var(--color-bg);
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    padding: 10px 12px;
+    overflow-x: auto;
+    margin: 6px 0;
+  }
+  .tool-card-body-inner-fixed .code-block pre {
+    font-family: 'Geist Mono', 'JetBrains Mono', monospace;
+    font-size: 11px;
+    line-height: 1.55;
+    color: var(--color-text);
+    white-space: pre;
+  }
+  .tool-card-body-inner-fixed .code-lang {
+    font-family: 'Geist Mono', monospace;
+    font-size: 9px;
+    color: var(--color-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin-bottom: 6px;
+    display: block;
+  }
+  .tool-card-body-inner-fixed .summary-line {
+    font-family: 'Geist Mono', monospace;
+    font-size: 11px;
+    color: var(--color-text);
+    line-height: 1.5;
+  }
+  .tool-card-body-inner-fixed .summary-hint {
+    font-size: 10px;
+    color: var(--color-text-muted);
+    font-style: italic;
+    margin-top: 4px;
+  }
+
+  /* ── MCP Rich List (same in both before/after — reference) ── */
+  .mcp-rich-list {
+    display: flex;
+    flex-direction: column;
+    border-top: 1px solid var(--color-border);
+  }
+  .mcp-rich-item {
+    padding: 12px 14px;
+    background: var(--color-bg);
+    border-bottom: 1px solid var(--color-border);
+    transition: background 0.15s;
+    font-family: 'Geist Sans', sans-serif;
+  }
+  .mcp-rich-item:last-child { border-bottom: none; }
+  .mcp-rich-item .r-head {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 6px;
+  }
+  .mcp-rich-item .r-title {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--color-text);
+    line-height: 1.4;
+  }
+  .mcp-rich-item .r-score {
+    flex-shrink: 0;
+    font-family: 'Geist Mono', monospace;
+    font-size: 9px;
+    font-weight: 600;
+    padding: 2px 7px;
+    border-radius: 10px;
+    background: var(--color-success);
+    color: var(--color-success-text);
+    white-space: nowrap;
+    margin-top: 2px;
+  }
+  .mcp-rich-item .r-url {
+    font-family: 'Geist Mono', monospace;
+    font-size: 10px;
+    color: var(--color-accent);
+    opacity: 0.7;
+    margin-bottom: 6px;
+    word-break: break-all;
+  }
+  .mcp-rich-item .r-content {
+    font-size: 12px;
+    color: var(--color-text-muted);
+    line-height: 1.55;
+  }
+
+  .mcp-raw-block {
+    padding: 12px 14px;
+    border-top: 1px solid var(--color-border);
+    font-family: 'Geist Mono', monospace;
+    font-size: 11px;
+    line-height: 1.55;
+    color: var(--color-text-muted);
+    max-height: 280px;
+    overflow-y: auto;
+    white-space: pre-wrap;
+    word-break: break-all;
+    background: var(--color-bg);
+  }
+
+  /* ── After: rich list for built-in JSON tools ── */
+  .builtin-rich-list {
+    display: flex;
+    flex-direction: column;
+    border-top: 1px solid var(--color-border);
+  }
+  .builtin-rich-item {
+    padding: 10px 14px;
+    background: var(--color-bg);
+    border-bottom: 1px solid var(--color-border);
+    font-family: 'Geist Sans', sans-serif;
+  }
+  .builtin-rich-item:last-child { border-bottom: none; }
+  .builtin-rich-item .br-head {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 4px;
+  }
+  .builtin-rich-item .br-icon {
+    font-size: 12px;
+    flex-shrink: 0;
+  }
+  .builtin-rich-item .br-name {
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--color-text);
+    font-family: 'Geist Mono', monospace;
+  }
+  .builtin-rich-item .br-meta {
+    font-family: 'Geist Mono', monospace;
+    font-size: 10px;
+    color: var(--color-text-muted);
+    margin-left: auto;
+  }
+  .builtin-rich-item .br-path {
+    font-family: 'Geist Mono', monospace;
+    font-size: 10px;
+    color: var(--color-accent);
+    opacity: 0.8;
+  }
+
+  /* ── Section separator ── */
+  .section-label {
+    max-width: 920px;
+    margin: 24px auto 10px;
+    font-size: 11px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--color-text-muted);
+    padding-bottom: 8px;
+    border-bottom: 1px solid var(--color-border);
+  }
+  .section-label:first-of-type {
+    margin-top: 0;
+  }
+
+  /* ── Annotations ── */
+  .annotation {
+    max-width: 920px;
+    margin: 8px auto 0;
+    padding: 10px 14px;
+    background: var(--color-warning);
+    border-radius: 6px;
+    font-size: 11px;
+    color: var(--color-warning-text);
+    line-height: 1.5;
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+  }
+  .annotation .ann-icon {
+    flex-shrink: 0;
+    font-weight: 700;
+  }
+  .annotation.ok {
+    background: var(--color-success);
+    color: var(--color-success-text);
+  }
+
+  /* hidden utility */
+  .hidden { display: none !important;; }
+</style>
+</head>
+<body>
+
+<div class="page-header">
+  <h1>Built-in Tool Result Rendering — Before vs After</h1>
+  <p>Compares the current broken line-by-line rendering with the proposed whole-Markdown approach. Toggle to view each mode, or use side-by-side.</p>
+</div>
+
+<div class="toggle-bar">
+  <div class="toggle-group">
+    <button class="toggle-btn active" data-mode="side">Side by Side</button>
+    <button class="toggle-btn" data-mode="before">Before Only</button>
+    <button class="toggle-btn" data-mode="after">After Only</button>
+  </div>
+  <span class="toggle-label" id="modeLabel">Showing both columns</span>
+</div>
+
+<!-- ═══════════════ Section 1: bash tool ═══════════════ -->
+<div class="section-label">bash — shell command output (code fence)</div>
+
+<div class="comparison" id="comp-bash">
+  <!-- BEFORE -->
+  <div class="col-before">
+    <div class="col-header">
+      Before <span class="tag tag-broken">BROKEN</span>
+    </div>
+    <div class="tool-card open">
+      <div class="tool-card-header">
+        <span class="status ok">✓</span>
+        <span class="name">bash</span>
+        <span class="args">npm run typecheck</span>
+        <span class="arrow">▾</span>
+      </div>
+      <div class="tool-card-body">
+        <div class="tool-card-body-inner-broken">
+          <span class="md-line broken-fence">```sh</span>
+          <span class="md-line">src/ui/web/web-backend.ts:146:5</span>
+          <span class="md-line">  const rs = formatToolResultForUI(e.name, rawResult);</span>
+          <span class="md-line">           ~~~~~~~~~~~~~~~~~~~~~~~~~~~</span>
+          <span class="md-line"></span>
+          <span class="md-line">src/ui/shared/reducer.ts:90:12</span>
+          <span class="md-line">  t.name === event.name && !t.result</span>
+          <span class="md-line">             ~~~~~~~~~~~~</span>
+          <span class="md-line broken-fence">```</span>
+          <span class="md-line">… (247 more chars)</span>
+        </div>
+      </div>
+    </div>
+    <div class="annotation">
+      <span class="ann-icon">⚠</span>
+      <span>Code fence <code>```sh</code> and closing <code>```</code> rendered as literal text. Each line is a separate &lt;Markdown&gt; instance — no code block formed.</span>
+    </div>
+  </div>
+
+  <!-- AFTER -->
+  <div class="col-after">
+    <div class="col-header">
+      After <span class="tag tag-fixed">FIXED</span>
+    </div>
+    <div class="tool-card open">
+      <div class="tool-card-header">
+        <span class="status ok">✓</span>
+        <span class="name">bash</span>
+        <span class="args">npm run typecheck</span>
+        <span class="arrow">▾</span>
+      </div>
+      <div class="tool-card-body">
+        <div class="tool-card-body-inner-fixed">
+          <div class="md-content">
+            <div class="code-block">
+              <span class="code-lang">sh</span>
+              <pre>src/ui/web/web-backend.ts:146:5
+  const rs = formatToolResultForUI(e.name, rawResult);
+           ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+src/ui/shared/reducer.ts:90:12
+  t.name === event.name && !t.result
+             ~~~~~~~~~~~~
+
+Found 2 errors in 2 files.</pre>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="annotation ok">
+      <span class="ann-icon">✓</span>
+      <span>Whole result passed to single &lt;Markdown&gt; — code fence renders as proper styled block with language label.</span>
+    </div>
+  </div>
+</div>
+
+<!-- ═══════════════ Section 2: read_file tool ═══════════════ -->
+<div class="section-label">read_file — file contents (code block)</div>
+
+<div class="comparison" id="comp-readfile">
+  <div class="col-before">
+    <div class="col-header">Before <span class="tag tag-broken">BROKEN</span></div>
+    <div class="tool-card open">
+      <div class="tool-card-header">
+        <span class="status ok">✓</span>
+        <span class="name">read_file</span>
+        <span class="args">src/ui/shared/tool-result-formatter.ts</span>
+        <span class="arrow">▾</span>
+      </div>
+      <div class="tool-card-body">
+        <div class="tool-card-body-inner-broken">
+          <span class="md-line broken-fence">```</span>
+          <span class="md-line">const DEFAULT_MAX_CHARS = 600;</span>
+          <span class="md-line"></span>
+          <span class="md-line">function extractWriteSummary(text: string): string {</span>
+          <span class="md-line">  const lines = text.split("\n");</span>
+          <span class="md-line">  const meaningful: string[] = [];</span>
+          <span class="md-line broken-fence">```</span>
+          <span class="md-line">… (412 more chars)</span>
+        </div>
+      </div>
+    </div>
+    <div class="annotation">
+      <span class="ann-icon">⚠</span>
+      <span>No syntax highlighting, no code block styling — just raw mono text with stray backticks.</span>
+    </div>
+  </div>
+
+  <div class="col-after">
+    <div class="col-header">After <span class="tag tag-fixed">FIXED</span></div>
+    <div class="tool-card open">
+      <div class="tool-card-header">
+        <span class="status ok">✓</span>
+        <span class="name">read_file</span>
+        <span class="args">src/ui/shared/tool-result-formatter.ts</span>
+        <span class="arrow">▾</span>
+      </div>
+      <div class="tool-card-body">
+        <div class="tool-card-body-inner-fixed">
+          <div class="md-content">
+            <div class="code-block">
+              <pre>const DEFAULT_MAX_CHARS = 600;
+
+function extractWriteSummary(text: string): string {
+  const lines = text.split("\n");
+  const meaningful: string[] = [];
+  for (const line of lines) {
+    if (meaningful.length >= 2) break;
+    const trimmed = line.trim();
+    if (trimmed.length > 0) {
+      meaningful.push(trimmed);
+    }
+  }
+  return meaningful.join("\n");
+}</pre>
+            </div>
+            <span class="summary-hint">… (412 more chars)</span>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="annotation ok">
+      <span class="ann-icon">✓</span>
+      <span>Proper code block with border, background, scroll. Truncation hint preserved below.</span>
+    </div>
+  </div>
+</div>
+
+<!-- ═══════════════ Section 3: grep JSON result ═══════════════ -->
+<div class="section-label">grep — JSON results (was plain text, now rich list)</div>
+
+<div class="comparison" id="comp-grep">
+  <div class="col-before">
+    <div class="col-header">Before <span class="tag tag-broken">BROKEN</span></div>
+    <div class="tool-card open">
+      <div class="tool-card-header">
+        <span class="status ok">✓</span>
+        <span class="name">grep</span>
+        <span class="args">pattern: "tool_end"</span>
+        <span class="arrow">▾</span>
+      </div>
+      <div class="tool-card-body">
+        <div class="tool-card-body-inner-broken">
+          <span class="md-line broken-fence">```json</span>
+          <span class="md-line">{</span>
+          <span class="md-line">  "matches": [</span>
+          <span class="md-line">    { "file": "web-backend.ts", "line": 152, "text": "tool_end" },</span>
+          <span class="md-line">    { "file": "reducer.ts", "line": 99, "text": "tool_end" }</span>
+          <span class="md-line">  ]</span>
+          <span class="md-line">}</span>
+          <span class="md-line broken-fence">```</span>
+        </div>
+      </div>
+    </div>
+    <div class="annotation">
+      <span class="ann-icon">⚠</span>
+      <span>JSON code fence broken — backticks show as text. No pretty-printing, no interactive list.</span>
+    </div>
+  </div>
+
+  <div class="col-after">
+    <div class="col-header">After <span class="tag tag-fixed">FIXED</span></div>
+    <div class="tool-card open">
+      <div class="tool-card-header">
+        <span class="status ok">✓</span>
+        <span class="name">grep</span>
+        <span class="args">pattern: "tool_end"</span>
+        <span class="arrow">▾</span>
+      </div>
+      <div class="tool-card-body">
+        <div class="tool-card-body-inner-fixed">
+          <div class="md-content">
+            <div class="code-block">
+              <span class="code-lang">json</span>
+              <pre>{
+  "matches": [
+    { "file": "web-backend.ts", "line": 152, "text": "tool_end" },
+    { "file": "reducer.ts", "line": 99, "text": "tool_end" }
+  ]
+}</pre>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="annotation ok">
+      <span class="ann-icon">✓</span>
+      <span>JSON pretty-printed inside proper code block with language label.</span>
+    </div>
+  </div>
+</div>
+
+<!-- ═══════════════ Section 4: write_file summary ═══════════════ -->
+<div class="section-label">write_file — summary with anchor preview (already works, but line-split hurts)</div>
+
+<div class="comparison" id="comp-writefile">
+  <div class="col-before">
+    <div class="col-header">Before <span class="tag tag-broken">DEGRADED</span></div>
+    <div class="tool-card open">
+      <div class="tool-card-header">
+        <span class="status ok">✓</span>
+        <span class="name">write_file</span>
+        <span class="args">src/index.ts</span>
+        <span class="arrow">▾</span>
+      </div>
+      <div class="tool-card-body">
+        <div class="tool-card-body-inner-broken">
+          <span class="md-line">Written 23577 bytes to /path/index.html</span>
+          <span class="md-line">New file version: fv_2a818c68</span>
+          <span class="md-line">… (8 more lines — anchor preview hidden)</span>
+        </div>
+      </div>
+    </div>
+    <div class="annotation">
+      <span class="ann-icon">⚠</span>
+      <span>Summary works but each line is independent &lt;Markdown&gt; — no styling cohesion, <code>word-break: break-all</code> mangles paths.</span>
+    </div>
+  </div>
+
+  <div class="col-after">
+    <div class="col-header">After <span class="tag tag-fixed">FIXED</span></div>
+    <div class="tool-card open">
+      <div class="tool-card-header">
+        <span class="status ok">✓</span>
+        <span class="name">write_file</span>
+        <span class="args">src/index.ts</span>
+        <span class="arrow">▾</span>
+      </div>
+      <div class="tool-card-body">
+        <div class="tool-card-body-inner-fixed">
+          <div class="md-content">
+            <p class="summary-line">✓ Written 23,577 bytes to <code style="font-family:'Geist Mono',monospace;font-size:11px;background:var(--color-accent-bg);color:var(--color-accent);padding:1px 4px;border-radius:3px;">/path/index.html</code></p>
+            <p class="summary-line" style="color:var(--color-text-muted);">New file version: <code style="font-family:'Geist Mono',monospace;font-size:11px;background:var(--color-accent-bg);color:var(--color-accent);padding:1px 4px;border-radius:3px;">fv_2a818c68</code></p>
+            <p class="summary-hint">… 8 more lines — anchor preview hidden</p>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="annotation ok">
+      <span class="ann-icon">✓</span>
+      <span>Summary rendered as cohesive Markdown — paths get inline code styling, <code>word-break</code> no longer mangles.</span>
+    </div>
+  </div>
+</div>
+
+<!-- ═══════════════ Section 5: list_files (JSON — new rich list) ═══════════════ -->
+<div class="section-label">list_files — JSON result (new: rich list for built-in tools)</div>
+
+<div class="comparison" id="comp-listfiles">
+  <div class="col-before">
+    <div class="col-header">Before <span class="tag tag-broken">BROKEN</span></div>
+    <div class="tool-card open">
+      <div class="tool-card-header">
+        <span class="status ok">✓</span>
+        <span class="name">list_files</span>
+        <span class="args">path: src/ui</span>
+        <span class="arrow">▾</span>
+      </div>
+      <div class="tool-card-body">
+        <div class="tool-card-body-inner-broken">
+          <span class="md-line broken-fence">```json</span>
+          <span class="md-line">[</span>
+          <span class="md-line">  { "path": "src/ui/backend.ts", "isDir": false, "name": "backend.ts", "depth": 0 },</span>
+          <span class="md-line">  { "path": "src/ui/conversation.ts", "isDir": false, "name": "conversation.ts", "depth": 0 },</span>
+          <span class="md-line">  { "path": "src/ui/mdx", "isDir": true, "name": "mdx", "depth": 0 }</span>
+          <span class="md-line">]</span>
+          <span class="md-line broken-fence">```</span>
+        </div>
+      </div>
+    </div>
+    <div class="annotation">
+      <span class="ann-icon">⚠</span>
+      <span>JSON fence broken. Compare to MCP tools which get rich list cards — built-in tools get nothing.</span>
+    </div>
+  </div>
+
+  <div class="col-after">
+    <div class="col-header">After <span class="tag tag-fixed">FIXED + ENHANCED</span></div>
+    <div class="tool-card open">
+      <div class="tool-card-header">
+        <span class="status ok">✓</span>
+        <span class="name">list_files</span>
+        <span class="args">path: src/ui</span>
+        <span class="arrow">▾</span>
+      </div>
+      <div class="tool-card-body">
+        <div class="tool-card-body-inner-fixed" style="padding:0;max-height:none;">
+          <div class="builtin-rich-list">
+            <div class="builtin-rich-item">
+              <div class="br-head">
+                <span class="br-icon">📄</span>
+                <span class="br-name">backend.ts</span>
+                <span class="br-meta">depth: 0</span>
+              </div>
+              <div class="br-path">src/ui/backend.ts</div>
+            </div>
+            <div class="builtin-rich-item">
+              <div class="br-head">
+                <span class="br-icon">📄</span>
+                <span class="br-name">conversation.ts</span>
+                <span class="br-meta">depth: 0</span>
+              </div>
+              <div class="br-path">src/ui/conversation.ts</div>
+            </div>
+            <div class="builtin-rich-item">
+              <div class="br-head">
+                <span class="br-icon">📁</span>
+                <span class="br-name">mdx</span>
+                <span class="br-meta">depth: 0 · dir</span>
+              </div>
+              <div class="br-path">src/ui/mdx</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="annotation ok">
+      <span class="ann-icon">✓</span>
+      <span>Optional enhancement: built-in tools that return JSON arrays get rich list cards (like MCP), with file/dir icons and metadata.</span>
+    </div>
+  </div>
+</div>
+
+<!-- ═══════════════ Section 6: MCP reference (unchanged) ═══════════════ -->
+<div class="section-label">MCP tool — reference (unchanged in both modes)</div>
+
+<div class="comparison single">
+  <div>
+    <div class="col-header">MCP Rich List <span class="tag" style="background:var(--color-accent-bg);color:var(--color-accent);">REFERENCE</span></div>
+    <div class="tool-card mcp open">
+      <div class="tool-card-header">
+        <span class="status ok">✓</span>
+        <span class="name">mcp__brave__search</span>
+        <span class="mcp-badge">MCP</span>
+        <span class="args">query: "react server components"</span>
+        <span class="arrow">▾</span>
+      </div>
+      <div class="tool-card-body">
+        <div class="mcp-rich-list">
+          <div class="mcp-rich-item">
+            <div class="r-head">
+              <span class="r-title">React Server Components — React Docs</span>
+              <span class="r-score">0.95</span>
+            </div>
+            <div class="r-url">https://react.dev/reference/react/ServerComponents</div>
+            <div class="r-content">React Server Components allow you to write UI that is rendered on the server and streamed to the client...</div>
+          </div>
+          <div class="mcp-rich-item">
+            <div class="r-head">
+              <span class="r-title">Understanding Server Components</span>
+              <span class="r-score">0.88</span>
+            </div>
+            <div class="r-url">https://vercel.com/blog/understanding-react-server</div>
+            <div class="r-content">A deep dive into how RSC works, the mental model, and how it differs from SSR...</div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="annotation ok">
+      <span class="ann-icon">✓</span>
+      <span>This is the quality bar built-in tools should match. The fix brings code blocks to parity; the rich-list enhancement is optional but recommended.</span>
+    </div>
+  </div>
+</div>
+
+<script>
+  const toggleBtns = document.querySelectorAll('.toggle-btn');
+  const modeLabel = document.getElementById('modeLabel');
+  const comparisons = document.querySelectorAll('.comparison');
+
+  toggleBtns.forEach(btn => {
+    btn.addEventListener('click', () => {
+      toggleBtns.forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+      const mode = btn.dataset.mode;
+
+      comparisons.forEach(comp => {
+        const before = comp.querySelector('.col-before');
+        const after = comp.querySelector('.col-after');
+
+        comp.classList.remove('single');
+
+        if (mode === 'side') {
+          before?.classList.remove('hidden');
+          after?.classList.remove('hidden');
+          comp.style.gridTemplateColumns = '1fr 1fr';
+          modeLabel.textContent = 'Showing both columns';
+        } else if (mode === 'before') {
+          before?.classList.remove('hidden');
+          after?.classList.add('hidden');
+          comp.style.gridTemplateColumns = '1fr';
+          modeLabel.textContent = 'Before only — current broken state';
+        } else if (mode === 'after') {
+          before?.classList.add('hidden');
+          after?.classList.remove('hidden');
+          comp.style.gridTemplateColumns = '1fr';
+          modeLabel.textContent = 'After only — proposed fix';
+        }
+      });
+    });
+  });
+
+  // Toggle tool cards on header click
+  document.querySelectorAll('.tool-card-header').forEach(header => {
+    header.addEventListener('click', () => {
+      const card = header.closest('.tool-card');
+      card.classList.toggle('open');
+    });
+  });
+</script>
+
+</body>
+</html>

--- a/docs/prototypes/settings-cache-management.html
+++ b/docs/prototypes/settings-cache-management.html
@@ -1,0 +1,316 @@
+<!DOCTYPE html>
+<html lang="en">
+<!--
+  Change: fix-file-upload-cache
+  Descriptor: settings-cache-management
+  Generated: 2026-07-15
+-->
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Settings — Cache Management</title>
+<style>
+  :root {
+    --color-bg: #f8f7f5;
+    --color-surface: #f3f2ef;
+    --color-surface-hover: #ebe9e5;
+    --color-border: #e6e4e0;
+    --color-text: #2d2a26;
+    --color-text-muted: #8a8580;
+    --color-accent: #ca8a04;
+    --color-accent-hover: #a07004;
+    --color-error-text: #9f2f2d;
+    --color-error: #fdebec;
+    --font-mono: 'SF Mono', 'JetBrains Mono', monospace;
+    --font-sans: system-ui, -apple-system, sans-serif;
+  }
+
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+
+  body {
+    background: var(--color-bg);
+    color: var(--color-text);
+    font-family: var(--font-sans);
+    padding: 24px;
+    display: flex;
+    justify-content: center;
+  }
+
+  .panel {
+    width: 300px;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    overflow: hidden;
+  }
+
+  .panel-tabs {
+    display: flex;
+    border-bottom: 1px solid var(--color-border);
+  }
+
+  .panel-tab {
+    flex: 1;
+    padding: 10px 0;
+    font-size: 12px;
+    font-weight: 500;
+    text-align: center;
+    background: none;
+    border: none;
+    font-family: inherit;
+    border-bottom: 2px solid transparent;
+    color: var(--color-text-muted);
+    cursor: pointer;
+  }
+  .panel-tab.active {
+    color: var(--color-accent);
+    border-bottom-color: var(--color-accent);
+  }
+
+  .panel-body {
+    padding: 12px;
+  }
+
+  .settings-block {
+    margin-bottom: 16px;
+  }
+  .settings-label {
+    font-size: 11px;
+    color: var(--color-text-muted);
+    margin-bottom: 6px;
+    display: block;
+  }
+  .settings-select, .settings-input {
+    width: 100%;
+    border-radius: 8px;
+    border: 1px solid var(--color-border);
+    background: var(--color-bg);
+    color: var(--color-text);
+    font-size: 12px;
+    padding: 8px 10px;
+    outline: none;
+    font-family: inherit;
+  }
+  .settings-input-row {
+    display: flex;
+    gap: 8px;
+  }
+  .settings-input-row .settings-input {
+    flex: 1;
+  }
+  .settings-btn {
+    font-size: 12px;
+    padding: 8px 14px;
+    border-radius: 6px;
+    border: 1px solid var(--color-accent);
+    background: var(--color-accent);
+    color: #fff;
+    cursor: pointer;
+    font-family: inherit;
+    font-weight: 500;
+    white-space: nowrap;
+  }
+  .settings-divider {
+    border: none;
+    border-top: 1px solid var(--color-border);
+    margin: 12px 0;
+  }
+  .settings-footer {
+    font-size: 11px;
+    color: var(--color-text-muted);
+    padding-top: 8px;
+    border-top: 1px solid var(--color-border);
+  }
+
+  /* Cache section */
+  .cache-block {
+    border-radius: 8px;
+    border: 1px solid var(--color-border);
+    background: var(--color-bg);
+    padding: 10px 12px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+  .cache-block.danger {
+    border-color: var(--color-error-text);
+  }
+  .cache-size {
+    font-family: var(--font-mono);
+    font-size: 16px;
+    font-weight: 600;
+  }
+  .cache-label {
+    font-size: 11px;
+    color: var(--color-text-muted);
+    display: block;
+    margin-top: 2px;
+  }
+  .cache-clear-btn {
+    font-size: 11px;
+    font-weight: 500;
+    padding: 6px 12px;
+    border-radius: 6px;
+    border: 1px solid var(--color-error-text);
+    background: transparent;
+    color: var(--color-error-text);
+    cursor: pointer;
+    font-family: inherit;
+  }
+  .cache-clear-btn:hover {
+    background: var(--color-error);
+  }
+  .cache-clear-btn:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+  .helper {
+    font-size: 10px;
+    color: var(--color-text-muted);
+    margin-top: 4px;
+  }
+</style>
+</head>
+<body>
+
+<div class="panel">
+  <div class="panel-tabs">
+    <button class="panel-tab">Sessions</button>
+    <button class="panel-tab">MCP</button>
+    <button class="panel-tab active">Settings</button>
+  </div>
+  <div class="panel-body">
+
+    <div class="settings-block">
+      <label class="settings-label">Provider</label>
+      <select class="settings-select" disabled><option>deepseek</option></select>
+    </div>
+
+    <div class="settings-block">
+      <label class="settings-label">Model</label>
+      <select class="settings-select" disabled><option>deepseek-chat</option></select>
+    </div>
+
+    <div class="settings-block">
+      <label class="settings-label">Thinking Level</label>
+      <select class="settings-select" disabled><option>off</option></select>
+    </div>
+
+    <div class="settings-block">
+      <label class="settings-label">API Key</label>
+      <div class="settings-input-row">
+        <input class="settings-input" type="password" placeholder="sk-..." disabled>
+        <button class="settings-btn" disabled>Set</button>
+      </div>
+    </div>
+
+    <div class="settings-block">
+      <label class="settings-label">Project Path</label>
+      <div class="settings-input-row">
+        <input class="settings-input" type="text" placeholder="/Users/..." disabled>
+        <button class="settings-btn" disabled>Set</button>
+      </div>
+    </div>
+
+    <hr class="settings-divider">
+
+    <!-- ═══ CACHE SECTION ═══ -->
+    <div class="settings-block">
+      <label class="settings-label">Upload Cache</label>
+      <div class="cache-block" id="cacheBlock">
+        <div>
+          <span class="cache-size" id="cacheSize">0 B</span>
+          <span class="cache-label" id="cacheSubtext">no cached files</span>
+        </div>
+        <button class="cache-clear-btn" id="clearBtn" disabled>Clear</button>
+      </div>
+      <div class="helper">Files stored in .dscode/uploads/</div>
+    </div>
+
+    <hr class="settings-divider">
+
+    <div class="settings-footer">Max Tokens: 131,072</div>
+  </div>
+</div>
+
+<!-- State Switcher -->
+<div style="position:fixed;top:12px;left:50%;transform:translateX(-50%);z-index:100;
+  display:flex;gap:6px;padding:6px 8px;border-radius:8px;
+  border:1px solid var(--color-border);background:var(--color-surface);
+  font-size:12px;font-family:var(--font-sans);">
+  <span style="color:var(--color-text-muted);font-size:10px;align-self:center;">Cache State&nbsp;</span>
+  <button onclick="setState('empty')" id="st-empty" style="padding:4px 10px;font-size:11px;border-radius:6px;border:1px solid var(--color-border);background:var(--color-accent);color:#fff;cursor:pointer;font-family:inherit;">Empty</button>
+  <button onclick="setState('small')" id="st-small" style="padding:4px 10px;font-size:11px;border-radius:6px;border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text-muted);cursor:pointer;font-family:inherit;">2.4 MB</button>
+  <button onclick="setState('medium')" id="st-medium" style="padding:4px 10px;font-size:11px;border-radius:6px;border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text-muted);cursor:pointer;font-family:inherit;">47 MB</button>
+  <button onclick="setState('large')" id="st-large" style="padding:4px 10px;font-size:11px;border-radius:6px;border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text-muted);cursor:pointer;font-family:inherit;">312 MB</button>
+  <button onclick="setState('loading')" id="st-loading" style="padding:4px 10px;font-size:11px;border-radius:6px;border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text-muted);cursor:pointer;font-family:inherit;">Loading...</button>
+  <button onclick="setState('clearing')" id="st-clearing" style="padding:4px 10px;font-size:11px;border-radius:6px;border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text-muted);cursor:pointer;font-family:inherit;">Clearing...</button>
+</div>
+
+<script>
+  var $size = document.getElementById('cacheSize');
+  var $sub = document.getElementById('cacheSubtext');
+  var $block = document.getElementById('cacheBlock');
+  var $btn = document.getElementById('clearBtn');
+
+  var buttons = {
+    empty: document.getElementById('st-empty'),
+    small: document.getElementById('st-small'),
+    medium: document.getElementById('st-medium'),
+    large: document.getElementById('st-large'),
+    loading: document.getElementById('st-loading'),
+    clearing: document.getElementById('st-clearing'),
+  };
+
+  function setState(s) {
+    // Update active button
+    Object.keys(buttons).forEach(function(k) {
+      buttons[k].style.background = 'var(--color-bg)';
+      buttons[k].style.color = 'var(--color-text-muted)';
+    });
+    if (buttons[s]) {
+      buttons[s].style.background = 'var(--color-accent)';
+      buttons[s].style.color = '#fff';
+    }
+
+    if (s === 'empty') {
+      $size.textContent = '0 B';
+      $sub.textContent = 'no cached files';
+      $block.classList.remove('danger');
+      $btn.disabled = true;
+    } else if (s === 'small') {
+      $size.textContent = '2.4 MB';
+      $sub.textContent = '7 files · 3 sessions';
+      $block.classList.remove('danger');
+      $btn.disabled = false;
+    } else if (s === 'medium') {
+      $size.textContent = '47 MB';
+      $sub.textContent = '23 files · 5 sessions';
+      $block.classList.remove('danger');
+      $btn.disabled = false;
+    } else if (s === 'large') {
+      $size.textContent = '312 MB';
+      $sub.textContent = '85 files · 12 sessions';
+      $block.classList.add('danger');
+      $btn.disabled = false;
+    } else if (s === 'loading') {
+      $size.textContent = '...';
+      $sub.textContent = 'calculating...';
+      $block.classList.remove('danger');
+      $btn.disabled = true;
+    } else if (s === 'clearing') {
+      $size.textContent = '...';
+      $sub.textContent = 'clearing...';
+      $block.classList.remove('danger');
+      $btn.disabled = true;
+      setTimeout(function() { setState('empty'); }, 1500);
+    }
+  }
+
+  $btn.addEventListener('click', function() {
+    if (!$btn.disabled) setState('clearing');
+  });
+</script>
+
+</body>
+</html>

--- a/openspec/changes/archive/2026-07-15-enforce-prototype-gate/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-15-enforce-prototype-gate/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-plus
+created: 2026-07-15

--- a/openspec/changes/archive/2026-07-15-enforce-prototype-gate/consolidate.md
+++ b/openspec/changes/archive/2026-07-15-enforce-prototype-gate/consolidate.md
@@ -1,0 +1,38 @@
+## 变更综述
+
+从探索模式中建立 HTML 优先的原型工作流，到通过 schema 级别的硬性约束强制执行原型门控——本次变更将原型从"可选约定"升级为"不可绕过的工作流阶段"，确保 explore → propose → apply 的流程不被跳过。
+
+## 变更时间线
+
+- 2026-07-14: `fix-explore-prototype-html` — 修复探索模式的原型流程，建立 HTML 优先的原型生成约定和 `docs/prototypes/` 输出目录
+- 2026-07-15: `enforce-prototype-gate` — 通过 schema 硬约束强制执行 prototype 门控，使 prototype 成为 tasks 的依赖项
+
+## 初始设计
+
+探索模式中的原型流程存在断裂：explore 命令引用了不存在的 `prototype.md` 格式和 `openspec instructions prototype` 命令。实际有效的工作流是"先做 HTML 原型，视觉迭代，再实现"，但工具链和约定并未与此对齐。
+
+`fix-explore-prototype-html` 修复了这个问题：
+- 将 explore 命令中的原型描述从 markdown 改为 HTML-first
+- 建立 `docs/prototypes/` 作为原型 HTML 文件的规范输出目录
+- 创建 `docs/prototypes/prototype.md` 约束文件，指定输出目录、命名规范、样式对齐规则
+- 定义了新的 capability `explore-prototype-workflow`
+
+## 修复记录
+
+### 修复: explore 原型 HTML 流程修复
+- **症状**: explore 命令引用不存在的 `prototype.md` 输出格式和 `openspec instructions prototype` 命令
+- **根因**: 工具链文档与实际工作流脱节——实际使用的是 HTML 原型迭代方式，但命令描述仍停留在旧的 markdown 概念
+- **修复**: 对齐命令文档（explore.md）、系统提示（AGENTS.md）、config.yaml，建立 `docs/prototypes/` 规范目录和约束文件
+
+## 最终状态
+
+OPSX 工作流中存在缺口：explore 模式可以跳过 propose 直接进入 apply。由于 prototype artifact 在 schema 中标记为"可选，不阻塞 apply"，即使 explore 期间创建了原型 HTML，也没有任何机制强制将其决策带入 change artifacts。
+
+`enforce-prototype-gate` 实现了硬性门控：
+
+- **Schema 硬门控**: `prototype` artifact 从可选改为强制；`tasks.requires` 添加 `prototype` 依赖，CLI 会在 prototype 不存在时阻止任务创建
+- **Prototype artifact 语义**: UI 变更时 prototype.md 引用 `docs/prototypes/` 中的 HTML 文件并捕获设计决策；非 UI 变更时写入 2 行存根
+- **无条件 explore → propose 流**: explore 命令的"Ending Discovery"部分始终指向 `/opsx:propose`，不再有 `/opsx:apply` 快捷路径
+- **Propose 原型感知**: propose 命令新增 step 0，检查 `docs/prototypes/` 中的 HTML 文件并将其纳入 prototype artifact
+- **配置对齐**: `openspec/config.yaml` 移除"Prototype does NOT block apply"，反映新的强制状态
+- **技能更新**: prototype-workflow 和 openspec-explore 技能对齐新流程

--- a/openspec/changes/archive/2026-07-15-enforce-prototype-gate/design.md
+++ b/openspec/changes/archive/2026-07-15-enforce-prototype-gate/design.md
@@ -1,0 +1,61 @@
+## Context
+
+The OPSX workflow has four commands: explore, propose, apply, archive. The `spec-driven-plus` schema defines artifacts: proposal → specs → design → prototype → tasks → consolidate. Currently `prototype` is optional with `requires: []` and `tasks.requires: [specs, design]` — prototype is not in the chain. This allows two failure modes: (1) explore skips directly to apply, and (2) even when propose is used, prototype can be skipped without consequence.
+
+The explore command's "Ending Discovery" section mentions propose as one option among several, and the propose command has no awareness of prototypes created during explore.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Enforce explore → propose → apply as the unconditional flow
+- Make prototype a schema-level hard gate: `tasks` cannot be created without `prototype`
+- For UI changes: prototype.md references HTML files from `docs/prototypes/`
+- For non-UI changes: prototype.md is a trivial stub (2 lines)
+- Propose command reads prototypes from explore and incorporates them
+
+**Non-Goals:**
+- Changing the openspec CLI engine itself (we only modify the project-level schema.yaml)
+- Making prototype conditional in the schema (openspec doesn't support conditional requires — the stub handles non-UI)
+- Creating change directories during explore (explore only thinks + prototypes)
+
+## Decisions
+
+### D1: `prototype.requires: [design]` (not `[proposal]`)
+
+Prototype should come after design because the prototype artifact references design decisions. Order: proposal → specs → design → prototype → tasks.
+
+**Alternative considered**: `prototype.requires: [proposal]` — rejected because prototype needs design context to be meaningful for UI changes.
+
+### D2: `tasks.requires: [specs, design, prototype]`
+
+Adding prototype to tasks' dependency list. This is the hard gate — the CLI itself blocks task creation.
+
+### D3: Non-UI stub instead of conditional schema
+
+Openspec's schema system uses static `requires` lists with no conditional logic. Rather than keeping prototype optional and relying on command-level enforcement (weak), we make it mandatory for ALL changes. Non-UI changes get a 2-line stub prototype.md. The value is not the stub content — it's forcing the question "is this a UI change?"
+
+### D4: Prototype template restructure
+
+The current prototype.md template is a generic visual direction doc (color palette, wireframe, interaction flow). It should become a **prototype manifest**:
+
+- For UI: lists HTML file paths from `docs/prototypes/`, summarizes decisions from visual iteration
+- For non-UI: "No prototype needed" + reason
+
+### D5: Three-location sync for commands
+
+Commands exist in `.dscode/commands/opsx/`, `.clinerules/workflows/`, and `.claude/commands/`. All three must be updated identically, with `.dscode/` as the canonical source.
+
+### D6: Explore ending — hard redirect to propose
+
+The "Ending Discovery" section currently lists propose as one option. Change it to: explore ALWAYS ends with "run /opsx:propose next." Remove any mention of /opsx:apply from explore's ending section.
+
+## Risks / Trade-offs
+
+- **Risk**: Existing in-flight changes (e.g., `fix-tool-result-rendering`, `subagent-design-proposal`) already have tasks but no prototype. After schema change, `openspec status` may show them as inconsistent.
+  - **Mitigation**: Add retroactive prototype.md stubs to in-flight changes as part of implementation.
+
+- **Risk**: Non-UI stub feels like ceremony for no value.
+  - **Trade-off**: The 2-line stub is the cost of a hard gate. The alternative (command-level enforcement) is weaker and can be bypassed. Accept the ceremony.
+
+- **Risk**: Explore creates HTML prototypes in `docs/prototypes/` before a change directory exists. The propose command needs to match prototype files to the change name.
+  - **Mitigation**: Propose step 0 checks `docs/prototypes/` for files matching `<change-name>-*.html`. Naming convention already established by prototype-workflow skill.

--- a/openspec/changes/archive/2026-07-15-enforce-prototype-gate/proposal.md
+++ b/openspec/changes/archive/2026-07-15-enforce-prototype-gate/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+The OPSX workflow has a gap: explore mode can skip directly to apply, bypassing propose. The prototype artifact is marked "optional, does not block apply" in the schema, so even when a prototype HTML is created during explore, nothing enforces carrying its decisions into the change artifacts. We need a hard gate: explore → propose → apply (unconditional), with the schema enforcing prototype as a dependency of tasks.
+
+## What Changes
+
+- **Schema hard gate**: `prototype` artifact changes from optional to mandatory; `tasks.requires` adds `prototype` as a dependency, so the CLI blocks task creation until prototype exists
+- **Prototype artifact semantics**: For UI changes, prototype.md references HTML files from `docs/prototypes/` and captures design decisions. For non-UI changes, prototype.md is a 2-line stub ("No prototype needed — reason")
+- **Unconditional explore → propose flow**: explore command's "Ending Discovery" section always directs to `/opsx:propose`, never `/opsx:apply`
+- **Propose prototype awareness**: propose command adds a step 0 to check `docs/prototypes/` for HTML files from explore and incorporate them into the prototype artifact
+- **Config alignment**: `openspec/config.yaml` removes "Prototype does NOT block apply" and reflects the new mandatory status
+- **Skill updates**: prototype-workflow and openspec-explore skills align to the new flow
+
+## Capabilities
+
+### New Capabilities
+_None._
+
+### Modified Capabilities
+- `explore-prototype-workflow`: Add requirements for the schema-level prototype gate (tasks depends on prototype), the unconditional explore → propose flow, and the propose command's prototype-awareness step
+
+## Impact
+
+- `openspec/schemas/spec-driven-plus/schema.yaml` — prototype.requires, tasks.requires, prototype description + instruction
+- `openspec/schemas/spec-driven-plus/templates/prototype.md` — rewrite as prototype manifest with HTML references + non-UI stub
+- `openspec/config.yaml` — remove "does not block apply", update prototype description
+- `.dscode/commands/opsx/explore.md` + `.clinerules/workflows/opsx-explore.md` + `.claude/commands/opsx/explore.md` — Ending Discovery section
+- `.dscode/commands/opsx/propose.md` + `.clinerules/workflows/opsx-propose.md` + `.claude/commands/opsx/propose.md` — add prototype check step
+- `.dscode/skills/prototype-workflow/SKILL.md` — step 6 redirect to /opsx:propose
+- `.dscode/skills/openspec-explore/SKILL.md` — ending section
+- `.dscode/skills/openspec-propose/SKILL.md` — add prototype awareness
+- Existing in-flight changes with `tasks` created but no `prototype` artifact will need a retroactive prototype.md stub

--- a/openspec/changes/archive/2026-07-15-enforce-prototype-gate/prototype.md
+++ b/openspec/changes/archive/2026-07-15-enforce-prototype-gate/prototype.md
@@ -1,0 +1,3 @@
+## Prototype Status
+
+No UI prototype needed — this change modifies the openspec schema, command files, and skill definitions. It does not introduce or modify any UI components, pages, or visual interaction patterns.

--- a/openspec/changes/archive/2026-07-15-enforce-prototype-gate/specs/explore-prototype-workflow/spec.md
+++ b/openspec/changes/archive/2026-07-15-enforce-prototype-gate/specs/explore-prototype-workflow/spec.md
@@ -1,0 +1,91 @@
+## ADDED Requirements
+
+### Requirement: Schema-level prototype gate
+The `spec-driven-plus` schema SHALL enforce `prototype` as a dependency of `tasks`. The `tasks` artifact's `requires` list SHALL include `prototype`, so the CLI blocks task creation until the prototype artifact exists.
+
+#### Scenario: Tasks blocked without prototype
+- **WHEN** a change's `prototype` artifact has not been created
+- **THEN** `openspec status` SHALL show `tasks` as `blocked` and `openspec instructions tasks` SHALL refuse to proceed
+
+#### Scenario: Tasks unblocked after prototype
+- **WHEN** a change's `prototype` artifact has been created (either UI manifest or non-UI stub)
+- **THEN** `tasks` SHALL become `ready` and `openspec instructions tasks` SHALL proceed normally
+
+### Requirement: Prototype artifact requires design
+The `prototype` artifact's `requires` list SHALL include `design`, ensuring prototype is created after design decisions are captured.
+
+#### Scenario: Prototype blocked without design
+- **WHEN** a change's `design` artifact has not been created
+- **THEN** `prototype` SHALL show as `blocked`
+
+### Requirement: Prototype artifact content for UI changes
+For changes involving UI components, pages, or visual interaction, the `prototype.md` artifact SHALL reference HTML prototype files from `docs/prototypes/` and capture key design decisions refined during visual iteration.
+
+#### Scenario: UI change prototype artifact
+- **WHEN** the change involves UI and HTML prototypes exist in `docs/prototypes/`
+- **THEN** `prototype.md` SHALL list each prototype file path, summarize the visual direction, and reference the design decisions confirmed during explore
+
+#### Scenario: UI change without HTML prototype
+- **WHEN** the change involves UI but no HTML prototype was created during explore
+- **THEN** `prototype.md` SHALL state that no prototype was generated and include a brief visual direction description based on design.md
+
+### Requirement: Prototype artifact content for non-UI changes
+For changes that do not involve UI, the `prototype.md` artifact SHALL contain a stub stating no prototype is needed with a one-line rationale.
+
+#### Scenario: Non-UI change prototype stub
+- **WHEN** the change is backend-only, config, or refactoring with no UI impact
+- **THEN** `prototype.md` SHALL contain a "No prototype needed" section with a brief reason (e.g., "backend-only change affecting X module")
+
+### Requirement: Unconditional explore to propose flow
+The explore command SHALL always direct the user to `/opsx:propose` as the next step after exploration. The explore command SHALL NEVER suggest `/opsx:apply` directly.
+
+#### Scenario: Explore ending with prototype
+- **WHEN** explore completes and an HTML prototype was created in `docs/prototypes/`
+- **THEN** the explore command SHALL say to run `/opsx:propose` next, mentioning the prototype will be incorporated
+
+#### Scenario: Explore ending without prototype
+- **WHEN** explore completes and no prototype was created
+- **THEN** the explore command SHALL say to run `/opsx:propose` next
+
+### Requirement: Propose command prototype awareness
+The propose command SHALL check `docs/prototypes/` for HTML prototype files matching the change name before creating the prototype artifact.
+
+#### Scenario: Propose finds prototype HTML
+- **WHEN** propose runs and `docs/prototypes/` contains HTML files matching the change name
+- **THEN** propose SHALL read those files and use them as design source-of-truth when creating the prototype artifact
+
+#### Scenario: Propose finds no prototype HTML
+- **WHEN** propose runs and no matching HTML prototypes exist
+- **THEN** propose SHALL create a non-UI stub prototype artifact (if the change has no UI impact) or offer to generate a prototype first (if the change has UI impact)
+
+## MODIFIED Requirements
+
+### Requirement: Explore command prototype section
+The explore command file (`.dscode/commands/opsx/explore.md`, `.clinerules/workflows/opsx-explore.md`, and `.claude/commands/opsx/explore.md`) SHALL contain a "Create HTML prototypes for frontend ideas" section under "What You Might Do" AND an "Ending Discovery" section that unconditionally directs to `/opsx:propose`.
+
+#### Scenario: Detection keywords
+- **WHEN** an explore discussion mentions UI, 页面, 界面, 组件, 交互, 样式, 视觉, CSS, frontend, landing, dashboard, 原型, prototype, redesign, or 动效
+- **THEN** the agent SHALL naturally offer to create an HTML prototype
+
+#### Scenario: Generation steps
+- **WHEN** the user accepts the prototype offer
+- **THEN** the agent SHALL: (1) read `docs/prototypes/prototype.md`, (2) load `html-output` skill, (3) extract `--color-*` variables from `web/index.css`, (4) generate self-contained HTML at `docs/prototypes/<name>.html`
+
+#### Scenario: Visual iteration
+- **WHEN** a prototype is generated
+- **THEN** the agent SHALL accept visual feedback and iterate on the HTML prototype before capturing final design decisions
+
+#### Scenario: Ending discovery unconditionally goes to propose
+- **WHEN** explore ends, regardless of whether a prototype was created
+- **THEN** the agent SHALL direct the user to `/opsx:propose` as the next step and SHALL NOT suggest `/opsx:apply`
+
+### Requirement: OpenSpec config alignment
+`openspec/config.yaml` SHALL describe the prototype artifact as mandatory and blocking tasks, consistent with the schema-level gate.
+
+#### Scenario: Config description reflects mandatory prototype
+- **WHEN** `openspec/config.yaml` is read
+- **THEN** the prototype artifact description SHALL state it is mandatory and blocks `tasks` creation — NOT "optional" or "does not block apply"
+
+#### Scenario: Config references HTML prototypes
+- **WHEN** `openspec/config.yaml` describes the prototype workflow
+- **THEN** it SHALL reference HTML prototypes, `docs/prototypes/`, and the `html-output` skill — not `prototype.md` as output and not `openspec instructions prototype` as the generation method

--- a/openspec/changes/archive/2026-07-15-enforce-prototype-gate/tasks.md
+++ b/openspec/changes/archive/2026-07-15-enforce-prototype-gate/tasks.md
@@ -1,0 +1,44 @@
+## 1. Schema hard gate
+
+- [x] 1.1 In `openspec/schemas/spec-driven-plus/schema.yaml`: change `prototype.requires` from `[]` to `[design]`
+- [x] 1.2 In `openspec/schemas/spec-driven-plus/schema.yaml`: change `tasks.requires` from `[specs, design]` to `[specs, design, prototype]`
+- [x] 1.3 In `openspec/schemas/spec-driven-plus/schema.yaml`: update prototype artifact description — remove "optional" and "does not block apply", state it is mandatory and blocks tasks
+- [x] 1.4 In `openspec/schemas/spec-driven-plus/schema.yaml`: rewrite prototype artifact instruction — reference HTML prototypes from `docs/prototypes/` for UI changes; describe non-UI stub format; remove "Do NOT write HTML/CSS code" (HTML is written during explore, not propose)
+
+## 2. Prototype template restructure
+
+- [x] 2.1 Rewrite `openspec/schemas/spec-driven-plus/templates/prototype.md` as a prototype manifest with two sections: (a) "Prototype Files" listing HTML paths from `docs/prototypes/` with design decision summaries for UI changes, (b) "Prototype Status" stub for non-UI changes
+
+## 3. Config alignment
+
+- [x] 3.1 In `openspec/config.yaml`: remove "Prototype does NOT block apply" from the prototype description
+- [x] 3.2 In `openspec/config.yaml`: update prototype description to state it is mandatory and blocks tasks creation
+
+## 4. Explore command — unconditional propose flow
+
+- [x] 4.1 In `.dscode/commands/opsx/explore.md`: rewrite "Ending Discovery" section — explore ALWAYS directs to `/opsx:propose`, never `/opsx:apply`; if prototype was created, mention it will be incorporated in propose
+- [x] 4.2 Copy updated explore.md to `.clinerules/workflows/opsx-explore.md`
+- [x] 4.3 Copy updated explore.md to `.claude/commands/opsx/explore.md`
+
+## 5. Propose command — prototype awareness
+
+- [x] 5.1 In `.dscode/commands/opsx/propose.md`: add step 0 before "Create the change directory" — check `docs/prototypes/` for HTML files matching the change name; if found, read them as design source-of-truth; if not found and change is UI, offer to generate prototype first; if not found and non-UI, proceed with stub
+- [x] 5.2 Copy updated propose.md to `.clinerules/workflows/opsx-propose.md`
+- [x] 5.3 Copy updated propose.md to `.claude/commands/opsx/propose.md`
+
+## 6. Skill updates
+
+- [x] 6.1 In `.dscode/skills/prototype-workflow/SKILL.md`: update step 6 from "capture into design.md / specs" to "guide user to run /opsx:propose — the prototype will be incorporated into the change's prototype artifact"
+- [x] 6.2 In `.dscode/skills/openspec-explore/SKILL.md`: update ending to unconditionally direct to `/opsx:propose`
+- [x] 6.3 In `.dscode/skills/openspec-propose/SKILL.md`: add prototype awareness — check `docs/prototypes/` before creating prototype artifact
+
+## 7. Retroactive stubs for in-flight changes
+
+- [x] 7.1 Add prototype.md stub to `openspec/changes/fix-tool-result-rendering/` (non-UI stub)
+- [x] 7.2 Add prototype.md stub to `openspec/changes/subagent-design-proposal/` (non-UI stub)
+
+## 8. Verification
+
+- [x] 8.1 Run `openspec status --change enforce-prototype-gate` and verify all artifacts are done
+- [x] 8.2 Run `openspec status --change fix-tool-result-rendering` and verify tasks is no longer blocked by missing prototype
+- [x] 8.3 Run `npm run typecheck` to ensure no code changes broke compilation

--- a/openspec/changes/archive/2026-07-15-fix-file-upload-cache/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-15-fix-file-upload-cache/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-plus
+created: 2026-07-15

--- a/openspec/changes/archive/2026-07-15-fix-file-upload-cache/consolidate.md
+++ b/openspec/changes/archive/2026-07-15-fix-file-upload-cache/consolidate.md
@@ -1,0 +1,65 @@
+## 变更综述
+
+文件拖拽上传功能从零到完整的演进历程：从 Web UI 支持拖拽插入 `@path`，到引入 `[file:xxx]` 格式协议和 FileTracker 统一 Web/TUI 两端的文件追踪，再到解除上传大小限制并增加缓存可见性与清理能力。最终状态是一个用户可以拖入文件、看到清晰的缓存状态、并能一键清理的完整闭环。
+
+## 变更时间线
+
+- 2026-07-08: web-drag-drop-files — Web UI 支持拖拽文件插入 `@path`，FileAttachment 类型、文件芯片、双向同步
+- 2026-07-08: drag-drop-file-attachments — `[file:xxx]` 格式协议 + FileTracker，统一 Web UI 和 TUI 的文件追踪
+- 2026-07-08: fix-at-image-size-limit — 修复 `@` 引用图片时的 50KB 限制（图片走 vision pipeline，不应受限）
+- 2026-07-15: fix-file-upload-cache — 解除文件上传大小限制，新增上传缓存展示与清理
+
+## 初始设计
+
+**问题**：Web UI 用户只能通过 `@` 自动补全或剪贴板粘贴引用文件，拖拽——最直观的方式——完全无效。帮助文本甚至声称支持拖拽，这是误导。
+
+**方案**：
+- Web UI 输入区接受拖拽的 `File` 对象，读取元数据（名称、大小、MIME、绝对路径），作为 `FileAttachment` 存入状态
+- 在文本区上方渲染文件芯片（图标 + 文件名 + 大小 + 删除按钮）
+- 将显示路径（项目内文件用相对路径，外部文件用绝对路径）作为 `@path` 插入文本区
+- 芯片与文本双向同步：删除芯片移除 `@path`，删除 `@path` 移除芯片
+
+## 变更记录
+
+### 变更: [file:xxx] 格式协议 + FileTracker
+
+- **触发**: 用户拖入文件后无法在编辑器中看到文件与提示词的关联（"review this" 和上面 attach 的三个文件没有可见连接）
+- **改动**: 引入 `[file:displayPath]` 纯文本标记协议（类似 `[image:N]`），在编辑器中可见、可输入、可删除。FileTracker 作为每消息的文件路径注册表，从编辑器的 `onChange` 事件中解析 `[file:xxx]` 标记来双向同步。TUI 拖拽插入 `[file:xxx]`，Web UI 保持芯片模式。提交时 `[file:xxx]` 保留在文本中传递给模型，同时 `fileRefs` 数组传递给后端解析器。
+- **影响**: Web UI 的 `handleDrop` 从插入 `@path` 改为注册 tracker + 芯片展示；TUI 新增拖拽处理和 attachment bar；`resolveFileRefs()` 新增函数处理显式路径数组
+
+### 变更: 图片 @ 引用大小限制修复
+
+- **触发**: `resolveAtFileRefs` 对所有文件统一施加 50KB 限制，导致 >50KB 的图片被静默跳过，模型收到原始 `@file.jpg` 文本后只能调用 `read_file`
+- **改动**: 移除图片的 `maxFileSize` 门禁，新增 `maxImageSize`（20MB）防止极端大图加载。图片不计入 `maxTotalSize`（它们走 vision pipeline 而非文本 token）
+- **影响**: `at-file-resolver.ts`、`AtFileConfig` 类型、配置默认值
+
+## 修复记录
+
+### 修复: 解除文件上传大小限制 + 缓存管理
+
+- **症状**: 拖入 PDF 等大文件到 Web UI 无任何反应——`MAX_FILE_SIZE = 50KB` / `MAX_TOTAL_SIZE = 200KB` 的硬限制太小，超出后静默丢弃。同时上传文件写入 `.dscode/uploads/` 后从不清理，缓存无限增长且用户无感知。
+- **根因**: 
+  - 前端 `MessageInput.tsx` 中常量 `MAX_FILE_SIZE = 50 * 1024`、`MAX_TOTAL_SIZE = 200 * 1024` 过于保守
+  - 缺少上传缓存大小查询和清理的后端接口
+  - Session 删除时未清理对应的上传目录
+- **修复**: 
+  - 单文件上限从 50KB → 10MB，总计从 200KB → 50MB，超出时 toast 提示而非静默丢弃
+  - Settings 面板新增 Cache 区块：显示总大小、文件数、session 数，超标时红色警告，一键 Clear
+  - 服务器端新增 `cache_size` 事件（查询）和 `clear_cache` 命令（清理）
+  - Session 删除时调用 `cleanupUploadDir(sessionId)` 清理对应上传目录
+
+## 最终状态
+
+**问题**：拖入 PDF 等大文件到 Web UI 没有任何反应——因为 `MAX_FILE_SIZE = 50KB` / `MAX_TOTAL_SIZE = 200KB` 的硬限制太小，超出后静默丢弃。同时文件上传后写入 `.dscode/uploads/` 但从不清理，缓存无限增长且用户无感知。
+
+**方案**：
+- **解除文件大小限制**：单文件上限从 50KB 提升到 10MB，总计从 200KB 提升到 50MB，超出时 toast 提示
+- **Settings 面板新增 Cache 区块**：显示上传缓存总大小和 Clear 按钮
+- **服务器端缓存查询和清理**：新增 `cache_size` 事件和 `clear_cache` 命令
+- **Session 删除时自动清理**：删除 session 时同步清理对应的上传缓存目录
+
+**新增能力**：
+- `web-upload-cache`: Settings 面板展示上传缓存大小并提供一键清除功能；服务器端提供查询和清理接口；session 删除时自动清理上传文件
+
+**修改能力**：
+- `web-drag-drop-files`: 文件大小限制从 50KB/200KB 改为 10MB/50MB，超出时 toast 提示而非静默丢弃

--- a/openspec/changes/archive/2026-07-15-fix-file-upload-cache/design.md
+++ b/openspec/changes/archive/2026-07-15-fix-file-upload-cache/design.md
@@ -1,0 +1,50 @@
+## Context
+
+当前 Web UI 的 `MessageInput` 组件通过拖拽接受非图片文件时，读取文件内容并通过 WebSocket 发送到后端。后端将内容写入 `<project>/.dscode/uploads/<sessionId>/` 目录。但存在两个问题：
+
+1. **文件大小限制过严**：`MAX_FILE_SIZE = 50KB`，多数文档类文件（PDF、DOCX 等）远超此阈值，被静默丢弃
+2. **缓存无管理**：上传文件永不清除（`cleanupUploadDir` 已定义但从无调用），也无 UI 展示缓存状态
+
+## Goals / Non-Goals
+
+**Goals:**
+- 单文件上限 10MB、总计 50MB，超出时 toast 提示
+- Settings 面板显示上传缓存总大小和 Clear 按钮
+- Session 删除时清理对应上传文件
+- 40MB 以上缓存时 UI 警告提示
+
+**Non-Goals:**
+- 不改变文件上传的存储路径（仍为 `.dscode/uploads/<sessionId>/`）
+- 不增加按 session 粒度的单独清理
+- 不做上传进度条
+
+## Decisions
+
+### 1. 缓存查询和清除通过 WebSocket 消息实现
+
+**方案**: 新增 `ClientCommand: { type: "cache", action: "size" | "clear" }` 和 `ServerEvent: { type: "cache_size", totalBytes: number, fileCount: number, sessionCount: number }`
+
+**替代方案考虑**:
+- HTTP REST 端点：需引入额外路由，与现有纯 WebSocket 通信模式不一致 → 拒绝
+- 用现有 `config` 命令扩展：语义不匹配 → 拒绝
+
+### 2. 缓存大小在 Settings 面板打开时自动查询
+
+每次切换到 Settings tab 时前端发送 `cache_size` 请求。不轮询、不推送变化（缓存只在用户主动操作时变化）。
+
+### 3. Clear 操作清除所有 session 的上传目录
+
+遍历 `.dscode/uploads/` 下所有子目录逐一删除，而非仅当前 session。用户视角下这是一个全局临时缓存。
+
+### 4. 文件大小严重超限时 toast 提示
+
+当单文件超过 10MB 或累计超过 50MB 时，不再 `continue` 静默跳过，而是调用 `addToast` 显示提示（如 "File 'report.pdf' exceeds 10 MB limit"）。
+
+### 5. 40MB 阈值触发 warning 样式
+
+`cacheBlock` 添加 `danger` class（红色边框 + 提示文案 "Consider clearing to free disk space"）。
+
+## Risks / Trade-offs
+
+- [Risk] Clear 操作删除其他 session 正在使用的上传文件 → Mitigation: 上传文件是临时副本，实际文件在用户本地。Clear 只影响"已发送但被模型引用的文件路径"，不会导致数据丢失
+- [Risk] 10MB 单文件限制可能导致大 PDF 仍被拒绝 → Mitigation: 文件内容通过 `readAsText` 读取为文本后发送，对于二进制文件可能无效。这是已知限制，不在本次 scope 内解决

--- a/openspec/changes/archive/2026-07-15-fix-file-upload-cache/proposal.md
+++ b/openspec/changes/archive/2026-07-15-fix-file-upload-cache/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+拖入 PDF 等大文件到 Web UI 没有任何反应 — 因为 `MAX_FILE_SIZE = 50KB` / `MAX_TOTAL_SIZE = 200KB` 的硬限制太小，超出后静默丢弃。同时文件上传后写入 `.dscode/uploads/` 但从不清理，缓存无限增长且用户无感知。
+
+## What Changes
+
+- **解除文件大小限制**：单文件上限从 50KB 提升到 10MB，总计从 200KB 提升到 50MB，超出时 toast 提示
+- **Settings 面板新增 Cache 区块**：显示上传缓存总大小和 Clear 按钮
+- **服务器端缓存查询和清理**：新增 `cache_size` 事件和 `clear_cache` 命令
+- **Session 删除时自动清理**：删除 session 时同步清理对应的上传缓存目录
+
+## Capabilities
+
+### New Capabilities
+- `web-upload-cache`: Settings 面板展示上传缓存大小并提供一键清除功能；服务器端提供查询和清理接口；session 删除时自动清理上传文件
+
+### Modified Capabilities
+- `web-drag-drop-files`: 文件大小限制从 50KB/200KB 改为 10MB/50MB，超出时 toast 提示而非静默丢弃
+
+## Impact
+
+- `web/src/components/MessageInput.tsx` — MAX_FILE_SIZE/MAX_TOTAL_SIZE 常量修改，新增 toast 提示
+- `web/src/components/Sidebar.tsx` — SettingsPanel 新增 Cache 区块
+- `src/ui/shared/types.ts` — ClientCommand 新增 `clear_cache`，ServerEvent 新增 `cache_size`
+- `src/ui/web/web-backend.ts` — 新增 cache_size 查询、clear_cache 处理、session 删除时调用 cleanupUploadDir

--- a/openspec/changes/archive/2026-07-15-fix-file-upload-cache/prototype.md
+++ b/openspec/changes/archive/2026-07-15-fix-file-upload-cache/prototype.md
@@ -1,0 +1,73 @@
+## Visual Direction
+
+延续现有 warm design system（`--color-*` tokens），无新增视觉风格。Cache 区块使用与 Settings 面板其他区块一致的布局：label + bordered block + helper text。
+
+- **颜色**: `--color-bg` 底、`--color-border` 边框，大容量时 border 变为 `--color-error-text`
+- **排版**: 缓存大小用 mono 字体（`Geist Mono`），16px bold；标签 11px muted
+- **间距**: 与其他 settings-block 一致（mb: 16px，内 padding: 10px 12px）
+
+## Layout
+
+```
+┌──────────────────────────────┐
+│  Sessions │ MCP │ Settings   │
+├──────────────────────────────┤
+│  Provider          [select]  │
+│  Model             [select]  │
+│  Thinking Level    [select]  │
+│  API Key       [input][Set]  │
+│  Project Path  [input][Set]  │
+│  ─────────────────────────── │
+│  Upload Cache                │  ← 新增
+│  ┌──────────────────────┐    │
+│  │ 47 MB        [Clear] │    │
+│  │ 23 files · 5 sess.   │    │
+│  └──────────────────────┘    │
+│  Files in .dscode/uploads/   │
+│  ─────────────────────────── │
+│  Max Tokens: 131,072         │
+└──────────────────────────────┘
+```
+
+## Interaction Flow
+
+```
+   Settings 打开
+        │
+        ▼
+  自动请求 cache_size ──▶ 显示 "..." loading
+        │
+   收到 cache_size 事件
+        │
+        ▼
+  显示 "X MB" / "X files · X sessions"
+        │
+  用户点 [Clear]
+        │
+        ▼
+  发送 clear_cache 命令 ──▶ 显示 "clearing..."
+        │
+   服务端清完，推送 cache_size (0 B)
+        │
+        ▼
+  显示 "0 B" / Clear button disabled
+```
+
+**状态列表**:
+- **empty**: `0 B`，Clear 禁用
+- **normal** (≤50MB): 正常显示，Clear 可用
+- **warning** (>50MB): 红色边框 `danger` class，helper 改 "Consider clearing to free disk space"
+- **loading**: `...` + 脉冲动画
+- **clearing**: `...` + 脉冲动画 → 自动跳 empty
+
+## Design References
+
+- 原型: `docs/prototypes/settings-cache-management.html`
+- 现有 SettingsPanel: `web/src/components/Sidebar.tsx` lines 403-686
+- Design tokens: `web/src/index.css`
+
+## Accessibility Notes
+
+- Clear 按钮使用 `--color-error-text` 红色，在亮/暗模式下对比度均达标
+- 禁用状态 opacity 0.4 作为视觉提示，同时 `cursor: not-allowed`
+- loading/clearing 状态用 CSS animation（无闪烁风险）

--- a/openspec/changes/archive/2026-07-15-fix-file-upload-cache/specs/web-drag-drop-files/spec.md
+++ b/openspec/changes/archive/2026-07-15-fix-file-upload-cache/specs/web-drag-drop-files/spec.md
@@ -1,9 +1,7 @@
-## Purpose
+## MODIFIED Requirements
 
-Enable Web UI users to drag files and directories from their OS file manager directly onto the chat input area, with file metadata displayed as chips and paths inserted as @ references into the message text.
-## Requirements
 ### Requirement: Web UI prompt accepts drag-and-drop files
-The Web UI `MessageInput` component SHALL accept files and directories dragged from the OS file manager onto the textarea or its surrounding input area. Non-image files SHALL be read as raw bytes (via `readAsArrayBuffer()`), encoded as base64, and uploaded to the server if they are within size limits. Dropped files that exceed size limits SHALL produce a toast notification.
+The Web UI `MessageInput` component SHALL accept files and directories dragged from the OS file manager onto the textarea or its surrounding input area. Non-image files SHALL be read as text and uploaded to the server if they are within size limits. Dropped files that exceed size limits SHALL produce a toast notification.
 
 #### Scenario: Single file drop (project file — relative path)
 - **WHEN** the user drags a file (`app.ts`) from within the project directory onto the Web UI input area
@@ -42,9 +40,8 @@ The Web UI `MessageInput` component SHALL accept files and directories dragged f
 
 #### Scenario: Non-image file within size limit
 - **WHEN** the user drops a non-image file (e.g., PDF, TXT) that is at most 10 MB and does not cause the total batch to exceed 50 MB
-- **THEN** the file content SHALL be read as raw bytes via `readAsArrayBuffer()` and encoded as base64
-- **AND** the base64-encoded content SHALL be transmitted to the server as an `uploadedFile`
-- **AND** the server SHALL decode the base64 content and write the original bytes to `.dscode/uploads/<sessionId>/<timestamp>-<filename>`
+- **THEN** the file content SHALL be read as text and uploaded to the server as an `uploadedFile`
+- **AND** the uploaded content SHALL be written to `.dscode/uploads/<sessionId>/<timestamp>-<filename>`
 
 #### Scenario: File exceeds single-file size limit
 - **WHEN** the user drops a non-image file larger than 10 MB
@@ -143,4 +140,3 @@ The help text in `commands.ts` SHALL accurately describe available image input m
 - **WHEN** the `/?` or `/help` command is issued
 - **THEN** the image/vision section SHALL NOT claim "In Web UI: drag & drop, paste, or click to upload images" if drag-and-drop or click-to-upload are not fully implemented
 - **AND** the text SHALL describe only currently supported methods: pasting images via Ctrl+V
-

--- a/openspec/changes/archive/2026-07-15-fix-file-upload-cache/specs/web-upload-cache/spec.md
+++ b/openspec/changes/archive/2026-07-15-fix-file-upload-cache/specs/web-upload-cache/spec.md
@@ -1,0 +1,86 @@
+## ADDED Requirements
+
+### Requirement: Settings panel displays upload cache size
+The Settings panel SHALL display the total size of uploaded files stored in `.dscode/uploads/`, along with file count and session count. The cache size SHALL be queried from the server each time the Settings tab becomes active.
+
+#### Scenario: Cache block shows size, file count, and session count
+- **WHEN** the user opens the Settings panel
+- **THEN** the Upload Cache block SHALL query the server for cache statistics
+- **AND** display total size in human-readable format (e.g., "47 MB")
+- **AND** display file count and session count (e.g., "23 files · 5 sessions")
+
+#### Scenario: Cache block shows zero state
+- **WHEN** the server reports 0 bytes of cache
+- **THEN** the cache size SHALL display "0 B"
+- **AND** the subtext SHALL display "no cached files"
+- **AND** the Clear button SHALL be disabled
+
+#### Scenario: Cache block shows loading state
+- **WHEN** the Settings tab becomes active and the cache size query is in flight
+- **THEN** the cache block SHALL display "..." as the size
+- **AND** the subtext SHALL indicate a loading state (e.g., "calculating...")
+- **AND** the Clear button SHALL be disabled during loading
+
+#### Scenario: Cache block shows warning for large cache
+- **WHEN** the server reports cache total exceeding 40 MB
+- **THEN** the cache block SHALL receive a visual warning treatment (danger border color using `--color-error-text`)
+- **AND** the helper text SHALL change to "Consider clearing to free disk space"
+
+#### Scenario: Cache block uses design tokens
+- **WHEN** the cache block renders
+- **THEN** it SHALL use semantic `--color-*` CSS custom properties for all colors
+- **AND** the cache size SHALL use mono font (Geist Mono)
+- **AND** labels SHALL use the muted text color token
+
+### Requirement: User can clear upload cache
+The Settings panel SHALL provide a Clear button that sends a command to the server to delete all uploaded files in `.dscode/uploads/`. The UI SHALL reflect the clearing state and update upon completion.
+
+#### Scenario: Clicking Clear deletes all uploads
+- **WHEN** the user clicks the Clear button
+- **THEN** a `{ type: "cache", action: "clear" }` command SHALL be sent to the server
+- **AND** the cache block SHALL enter a clearing state showing "..." with the Clear button disabled
+- **AND** upon receiving the updated `cache_size` event, the block SHALL update to show zero
+
+#### Scenario: Clear button disabled when cache is empty
+- **WHEN** the cache size is 0
+- **THEN** the Clear button SHALL be disabled
+
+#### Scenario: Clear button enabled when cache is non-empty
+- **WHEN** the cache size is greater than 0
+- **THEN** the Clear button SHALL be enabled
+
+### Requirement: Server provides cache statistics endpoint
+The WebSocket server SHALL support a `{ type: "cache", action: "size" }` client command and respond with a `{ type: "cache_size", totalBytes, fileCount, sessionCount }` server event. The server SHALL recursively scan the `<project>/.dscode/uploads/` directory.
+
+#### Scenario: Server responds with cache statistics
+- **WHEN** the server receives `{ type: "cache", action: "size" }`
+- **THEN** it SHALL scan `.dscode/uploads/` for all files across all session subdirectories
+- **AND** respond with `{ type: "cache_size", totalBytes: number, fileCount: number, sessionCount: number }`
+
+#### Scenario: Server handles missing upload directory
+- **WHEN** the `.dscode/uploads/` directory does not exist
+- **THEN** the server SHALL respond with `{ type: "cache_size", totalBytes: 0, fileCount: 0, sessionCount: 0 }`
+
+### Requirement: Server clears upload cache on command
+The WebSocket server SHALL support a `{ type: "cache", action: "clear" }` client command. It SHALL remove all files and directories under `.dscode/uploads/` and respond with an updated `cache_size` event showing zero.
+
+#### Scenario: Clear removes all upload directories
+- **WHEN** the server receives `{ type: "cache", action: "clear" }`
+- **THEN** it SHALL recursively delete all contents of `.dscode/uploads/`
+- **AND** respond with `{ type: "cache_size", totalBytes: 0, fileCount: 0, sessionCount: 0 }`
+
+#### Scenario: Clear when directory is already empty
+- **WHEN** the upload directory does not exist or is empty
+- **THEN** the clear operation SHALL complete without error
+- **AND** respond with `{ type: "cache_size", totalBytes: 0, fileCount: 0, sessionCount: 0 }`
+
+### Requirement: Session deletion cleans up upload cache
+When a session is deleted, the server SHALL also delete the corresponding upload directory at `.dscode/uploads/<sessionId>/`.
+
+#### Scenario: Deleting session removes its upload files
+- **WHEN** a session is deleted
+- **THEN** the server SHALL call `cleanupUploadDir(sessionId)` to remove `.dscode/uploads/<sessionId>/`
+
+#### Scenario: Deleting session without uploads is safe
+- **WHEN** a session is deleted but `.dscode/uploads/<sessionId>/` does not exist
+- **THEN** the cleanup SHALL not throw or produce an error

--- a/openspec/changes/archive/2026-07-15-fix-file-upload-cache/tasks.md
+++ b/openspec/changes/archive/2026-07-15-fix-file-upload-cache/tasks.md
@@ -1,0 +1,49 @@
+## 1. Shared types — cache protocol
+
+- [x] 1.1 Add `{ type: "cache"; action: "size" | "clear" }` to `ClientCommand` union in `src/ui/shared/types.ts`
+- [x] 1.2 Add `{ type: "cache_size"; totalBytes: number; fileCount: number; sessionCount: number }` to `ServerEvent` union in `src/ui/shared/types.ts`
+- [x] 1.3 Run `npm run typecheck` and verify no type errors in shared types
+
+## 2. Server-side cache management (web-backend.ts)
+
+- [x] 2.1 Add `handleCache` method to `WebUiBackend` that handles `{ type: "cache", action: "size" }` — scans `.dscode/uploads/` recursively, sums file sizes, counts files and session directories, responds with `cache_size` event
+- [x] 2.2 Add handling for `{ type: "cache", action: "clear" }` — calls `rmSync` on `.dscode/uploads/` recursively, then responds with `cache_size` showing 0
+- [x] 2.3 Wire `cache` case in `handleMessage` switch to call `handleCache`
+- [x] 2.4 Wire `cleanupUploadDir(sessionId)` into session deletion path — find the `session` → `delete` handler and call cleanup after successful deletion
+- [x] 2.5 Run `npm run typecheck` and verify web-backend compiles
+
+## 3. Frontend — file size limits (MessageInput.tsx)
+
+- [x] 3.1 Change `MAX_FILE_SIZE` from `50 * 1024` to `10 * 1024 * 1024` (10 MB)
+- [x] 3.2 Change `MAX_TOTAL_SIZE` from `200 * 1024` to `50 * 1024 * 1024` (50 MB)
+- [x] 3.3 In `handleDrop`, when a non-image file exceeds the single-file limit, skip it AND produce a toast via a new `onToast` callback prop (format: "File '<name>' exceeds 10 MB limit")
+- [x] 3.4 When the total batch exceeds the total limit, skip remaining files AND produce a toast via `onToast` (format: "Total file size exceeds 50 MB limit")
+- [x] 3.5 Add `onToast?: (type: "warning" | "error", text: string) => void` to `MessageInputProps` interface
+- [x] 3.6 Run `npm run typecheck` and verify MessageInput compiles
+
+## 4. Frontend — cache block in Settings panel (Sidebar.tsx)
+
+- [x] 4.1 Add `cacheSize` state to `SettingsPanel` (type: `{ totalBytes: number; fileCount: number; sessionCount: number } | null`)
+- [x] 4.2 Add `cacheClearing` boolean state to `SettingsPanel`
+- [x] 4.3 On Settings tab activation, send `{ type: "cache", action: "size" }` command — add `onCacheAction` callback to `SidebarProps` and `SettingsPanelProps`
+- [x] 4.4 Render Upload Cache block between "Project Path" and the vision model section: bordered card with size (mono font, 16px), subtext ("X files · X sessions"), and Clear button
+- [x] 4.5 Apply `danger` styling when `totalBytes > 40 * 1024 * 1024` (red border, "Consider clearing" helper)
+- [x] 4.6 Clear button sends `{ type: "cache", action: "clear" }` and enters clearing state
+- [x] 4.7 When `cacheSize` is null, show loading state ("..." + "calculating..."); when zero, show "0 B" and disable Clear button
+- [x] 4.8 Run `npm run typecheck` and verify Sidebar compiles
+
+## 5. Frontend — wire everything in App.tsx
+
+- [x] 5.1 Add `handleCacheAction` callback that sends cache commands via WebSocket
+- [x] 5.2 Handle `cache_size` server event in `handleEvent` — update state passed to SettingsPanel
+- [x] 5.3 Pass `onToast` to `MessageInput` wrapping `addToast` for size-limit warnings
+- [x] 5.4 Pass `onCacheAction` and `cacheSize`/`cacheClearing` state to `Sidebar` → `SettingsPanel`
+- [x] 5.5 Run `npm run typecheck` and verify App.tsx compiles
+
+## 6. Validation
+
+- [x] 6.1 Manual test: drag a PDF >10MB and verify toast appears, file not uploaded
+- [x] 6.2 Manual test: drag a small PDF (<10MB), open Settings → verify cache size updates
+- [x] 6.3 Manual test: click Clear Cache → verify cache resets to 0 B
+- [x] 6.4 Manual test: delete a session that has uploads → verify `.dscode/uploads/<sessionId>/` is removed
+- [x] 6.5 Run `npm test` and verify no regressions

--- a/openspec/changes/archive/2026-07-15-fix-image-pipeline-uncompressed-images/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-15-fix-image-pipeline-uncompressed-images/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-plus
+created: 2026-07-15

--- a/openspec/changes/archive/2026-07-15-fix-image-pipeline-uncompressed-images/consolidate.md
+++ b/openspec/changes/archive/2026-07-15-fix-image-pipeline-uncompressed-images/consolidate.md
@@ -1,0 +1,31 @@
+## 变更综述
+
+图像管线中压缩缓存一直存在但从未被实际使用——`ImageCache.put()` 将图片压缩为 480px PNG 写入磁盘，但 `ImagePipeline.process()` 始终将原始未压缩图片传给 vision model 和 OCR。这导致大图（如 871KB JPEG）的 base64 编码过大，vision API 调用失败后回退到 OCR，OCR 在高分辨率未压缩数据上产生乱码。本修复让管线正确读取并使用压缩后的缓存图片。
+
+## 变更时间线
+
+- 2025-05-29: session-mm-vision-pipeline — 引入 vision pipeline 和 ImageCache
+- 2026-07-15: fix-image-pipeline-uncompressed-images — 修复管线未使用压缩缓存的问题
+
+## 初始设计
+
+**问题**：需要支持多模态 vision 模型处理用户上传的图片。
+
+**方案**：`ImagePipeline.process()` 接收图片 → `ImageCache.put()` 用 sharp 压缩为 480px PNG 并缓存 → 调用 vision model 描述图片 → 失败时回退到 OCR。
+
+## 修复记录
+
+### 修复: 管线未使用压缩后的缓存图片
+
+- **症状**: 拖入 `C罗.jpg`（871KB）到 TUI 产生 `<image_text>` 乱码 OCR 输出（`"4 hm 等 会 > dlr a 一 = FRA 3"`），而更小的 `mubapei.jpeg` 正常走 vision model。管线向 vision API 发送未压缩的 base64（871KB JPEG → ~1.16MB base64），对大图超过 API 限制或超时，vision 调用失败后 OCR 在同样的大图上产生垃圾。
+- **根因**: `ImagePipeline.process()` 在 `ImageCache.put()` 压缩并缓存图片后，仍然将原始 `normalizedImages` 传给 `describeImagesViaVisionModel()` 和 `ocrImages()`。压缩缓存只用于 progress callback，从未用于实际的 API 调用。
+- **修复**: 在 `ImageCache.put()` 返回后，用 `Promise.all` 并行调用 `ImageCache.get()` 读取压缩图片，传给 vision model 和 OCR。`get()` 返回 `null` 时回退到原始图片。仅修改 `src/drivers/vision/pipeline.ts` 一个文件。
+
+## 最终状态
+
+**问题**: `ImagePipeline.process()` 压缩图片但不使用压缩结果，导致大图 vision API 调用失败，OCR 产生乱码。
+
+**方案**: `ImageCache.put()` 压缩缓存后 → `Promise.all` 并行读取压缩图片 → 传递给 vision model 和 OCR → `get()` 失败时回退原始图片。
+
+**新增能力**:
+- `image-pipeline-compressed`: ImagePipeline 将压缩后的缓存图片传递给 vision model 和 OCR，确保大图正常处理

--- a/openspec/changes/archive/2026-07-15-fix-image-pipeline-uncompressed-images/design.md
+++ b/openspec/changes/archive/2026-07-15-fix-image-pipeline-uncompressed-images/design.md
@@ -1,0 +1,85 @@
+## Context
+
+`ImagePipeline.process()` currently compresses images to disk cache but passes uncompressed originals to both the vision model and OCR. This causes large images to fail the vision API call, degrading to garbled OCR output.
+
+The pipeline flow today:
+
+```
+normalizedImages (uncompressed base64)
+    │
+    ├─ ImageCache.put() → sharp 480px PNG → disk (cachedRefs)
+    │
+    └─ describeImagesViaVisionModel(normalizedImages, ...)  ← uncompressed!
+         │  ❌ fails for large images
+         ▼
+       ocrImages(normalizedImages)  ← uncompressed!
+         │  ❌ Tesseract struggles with high-res
+         ▼
+       garbled output
+```
+
+## Goals
+
+- Vision model receives compressed images (≤480px height PNG)
+- OCR also receives compressed images for better accuracy
+- No change to `ImageCache` public API
+- No change to `describeImagesViaVisionModel` or `ocrImages` signatures
+- Preserve existing cache deduplication behavior
+
+## Non-Goals
+
+- Not changing the compression parameters (480px, PNG format)
+- Not adding new image formats
+- Not modifying the web frontend image handling
+
+## Decisions
+
+### Decision 1: Read compressed images back from cache after put
+
+After `ImageCache.put()` compresses and caches all images, read them back via `ImageCache.get()` to get the compressed `ImageContent[]`, then pass those to the vision model and OCR.
+
+```
+normalizedImages (uncompressed base64)
+    │
+    ├─ ImageCache.put() → sharp 480px PNG → disk
+    │
+    ├─ ImageCache.get(cachedRefs) → compressed ImageContent[]
+    │
+    ├─ describeImagesViaVisionModel(compressed, ...)  ← compressed!
+    │
+    └─ ocrImages(compressed)  ← compressed!
+```
+
+**Why this approach:**
+- Reuses existing `ImageCache.get()` which already reads cached files back as `ImageContent`
+- No new compression logic needed
+- Cache deduplication still works (subsequent `put` calls are no-ops for same hash)
+- The `get` after `put` reads from warm disk cache — negligible overhead
+
+**Alternative considered:**
+- **In-memory compression**: Add a new method to `ImageCache` that compresses and returns `ImageContent` without disk I/O. Rejected because it duplicates logic and the disk I/O after write is minimal.
+- **Change `ImageCache.put` to also return compressed data**: Would change the public API return type. Rejected for minimal scope.
+
+### Decision 2: Keep original images when sharp is unavailable
+
+When `sharp` is not installed, `ImageCache.put()` stores the original uncompressed data. In this case:
+- `ImageCache.get()` returns the same uncompressed data
+- The behavior is identical to today (no regression)
+- A warning is already logged: `"sharp not available, images will be stored uncompressed"`
+
+### Decision 3: Batch readback
+
+Read all compressed images back in a single `Promise.all`:
+
+```typescript
+const compressedImages = await Promise.all(
+  cachedRefs.map(ref => ImageCache.get(ref))
+);
+// Filter out nulls (cache miss should never happen right after put)
+const validImages = compressedImages.filter((img): img is ImageContent => img !== null);
+```
+
+## Risks
+
+- **[Low] Cache readback could fail if disk is full or permissions change between put and get**: Handle by falling back to original `normalizedImages` if any `get` returns null.
+- **[Low] Compressed PNG may be larger than original JPEG for some images**: Sharp's 480px resize + PNG output is consistently smaller than original high-resolution photos. Edge case of very small images (<480px) would produce similar or slightly larger PNG, but still within API limits.

--- a/openspec/changes/archive/2026-07-15-fix-image-pipeline-uncompressed-images/proposal.md
+++ b/openspec/changes/archive/2026-07-15-fix-image-pipeline-uncompressed-images/proposal.md
@@ -1,0 +1,28 @@
+# fix-image-pipeline-uncompressed-images
+
+## Summary
+
+`ImagePipeline.process()` compresses images via `ImageCache.put()` (sharp → 480px PNG) and saves them to disk, but then passes the **original uncompressed** `normalizedImages` to `describeImagesViaVisionModel()`. The compressed cached versions are only used for progress callbacks, never for the actual vision API call.
+
+This causes large images to fail the vision API call → fall through to OCR → OCR on high-resolution uncompressed images produces garbled text.
+
+## Motivation
+
+User reported: dragging `C罗.jpg` (871KB) into TUI produces `<image_text>` with garbled OCR output (`"4 hm 等 会 > dlr a 一 = FRA 3"`), while `mubapei.jpeg` (smaller) works correctly via vision model.
+
+Root cause: The pipeline sends uncompressed base64 (~1.16MB for an 871KB JPEG) to the vision API. For large images, this can exceed API limits or cause timeouts. When the vision call fails, OCR runs on the same large uncompressed data and produces garbage.
+
+## Scope
+
+- **In scope**: Modify `ImagePipeline.process()` to use compressed cached images for vision model and OCR calls
+- **Out of scope**: Changes to ImageCache API, changes to vision model configuration, changes to the web frontend
+
+## Resolution
+
+After `ImageCache.put()` compresses and caches all images, the pipeline now reads them back via `ImageCache.get()` and passes the compressed versions to both `describeImagesViaVisionModel()` and `ocrImages()`. If any cache readback returns `null`, the pipeline falls back to the original uncompressed images.
+
+**Verified**: `C罗.jpg` (871KB) now correctly goes through the vision model instead of falling through to garbled OCR output.
+
+## Affected components
+
+- `src/drivers/vision/pipeline.ts` — `ImagePipeline.process()` method (only file changed)

--- a/openspec/changes/archive/2026-07-15-fix-image-pipeline-uncompressed-images/specs/image-pipeline-compressed/spec.md
+++ b/openspec/changes/archive/2026-07-15-fix-image-pipeline-uncompressed-images/specs/image-pipeline-compressed/spec.md
@@ -1,0 +1,52 @@
+## ADDED Requirements
+
+### Requirement: ImagePipeline SHALL pass compressed cached images to vision model
+After `ImageCache.put()` compresses all images and returns `cachedRefs`, the pipeline SHALL read the compressed images back via `ImageCache.get()` and pass the compressed `ImageContent[]` to `describeImagesViaVisionModel()` instead of the original uncompressed images.
+
+#### Scenario: Large JPEG image goes through vision model with compressed data
+- **WHEN** a user submits a 871KB JPEG image through TUI drag-and-drop
+- **AND** sharp is available for compression
+- **THEN** `ImageCache.put()` SHALL compress the image to ≤480px height PNG and cache it
+- **AND** the pipeline SHALL read the compressed image back via `ImageCache.get()`
+- **AND** the compressed image SHALL be passed to `describeImagesViaVisionModel()`
+- **AND** the vision model SHALL receive the compressed PNG data, not the original 871KB JPEG base64
+
+#### Scenario: Small image that doesn't need resize
+- **WHEN** a user submits a small image (≤480px height)
+- **AND** sharp is available
+- **THEN** `ImageCache.put()` SHALL convert it to PNG without resizing
+- **AND** the pipeline SHALL still pass the cached (converted) version to the vision model
+
+### Requirement: ImagePipeline SHALL pass compressed cached images to OCR fallback
+When the vision model call fails and the pipeline falls back to OCR, it SHALL pass the compressed `ImageContent[]` (read from cache via `ImageCache.get()`) to `ocrImages()` instead of the original uncompressed images.
+
+#### Scenario: Vision model fails, OCR receives compressed image
+- **WHEN** `describeImagesViaVisionModel()` throws an error or returns empty
+- **AND** the pipeline enters the OCR fallback path
+- **THEN** the compressed images from cache SHALL be passed to `ocrImages()`
+- **AND** OCR SHALL run on the 480px PNG version, not the original high-resolution image
+
+### Requirement: Readback failure SHALL fall back to original images
+If any `ImageCache.get(cachedRef)` returns `null` (cache miss), the pipeline SHALL fall back to using the original uncompressed images for the downstream call.
+
+#### Scenario: Cache file deleted between put and get
+- **WHEN** `ImageCache.put()` succeeds and returns a valid `ImageRef`
+- **BUT** the cached file is deleted from disk before `ImageCache.get()` reads it
+- **THEN** `ImageCache.get()` SHALL return `null`
+- **AND** the pipeline SHALL fall back to using the original `normalizedImages`
+- **AND** the pipeline SHALL NOT crash or throw
+
+#### Scenario: Sharp not available, original images used
+- **WHEN** sharp is not installed
+- **AND** `ImageCache.put()` stores the original uncompressed data
+- **THEN** `ImageCache.get()` SHALL return the same uncompressed data
+- **AND** the pipeline SHALL pass it to the vision model and OCR (no regression from current behavior)
+
+### Requirement: Batch readback SHALL be parallel
+All `ImageCache.get()` calls for a batch of images SHALL be issued in parallel via `Promise.all` before the first downstream call.
+
+#### Scenario: Multiple images submitted together
+- **WHEN** a user submits 3 images in a single message
+- **AND** all 3 are compressed and cached by `ImageCache.put()`
+- **THEN** all 3 SHALL be read back from cache in parallel via `Promise.all`
+- **AND** the compressed array SHALL be passed to the vision model as a single batch

--- a/openspec/changes/archive/2026-07-15-fix-image-pipeline-uncompressed-images/tasks.md
+++ b/openspec/changes/archive/2026-07-15-fix-image-pipeline-uncompressed-images/tasks.md
@@ -1,0 +1,15 @@
+## 1. Modify ImagePipeline.process() to use compressed images
+
+- [x] 1.1 After `ImageCache.put()` returns `cachedRefs`, add a parallel `ImageCache.get()` batch read to obtain compressed `ImageContent[]`
+- [x] 1.2 Add fallback: if any `get()` returns null, fall back to original `normalizedImages`
+- [x] 1.3 Pass compressed images to `describeImagesViaVisionModel()` instead of `normalizedImages`
+- [x] 1.4 Pass compressed images to `ocrImages()` instead of `normalizedImages`
+
+## 2. TypeScript and test
+
+- [x] 2.1 Run `npm run typecheck` to verify no type errors
+- [x] 2.2 Run `npm test` to verify no regressions
+- [ ] 2.3 Manual test (TUI): drag a large JPEG (>500KB), verify it goes through vision model and not OCR
+- [ ] 2.4 Manual test (TUI): drag a small image, verify still works
+- [ ] 2.5 Manual test (Web): drag a large JPEG, verify vision model path
+- [ ] 2.6 Manual test: verify cached files are used (check `~/.dscode/data/images/` for PNG files)

--- a/openspec/changes/archive/2026-07-15-fix-tool-result-rendering/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-15-fix-tool-result-rendering/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-plus
+created: 2026-07-15

--- a/openspec/changes/archive/2026-07-15-fix-tool-result-rendering/consolidate.md
+++ b/openspec/changes/archive/2026-07-15-fix-tool-result-rendering/consolidate.md
@@ -1,0 +1,38 @@
+## 变更综述
+
+从统一工具结果截断逻辑消除双管道不一致，到增强格式化实现代码高亮，再到修复 ToolCard 中 Markdown 组件因继承 CSS 属性导致的渲染错误——本次变更修复了内置工具结果的格式破损（JSON 单行、代码块结构丢失、过量空白）以及 MCP 工具结果缺少 Markdown 渲染的问题。
+
+## 变更时间线
+
+- 2025-07-14: `unify-tool-result-formatting` — 统一两条展示管道的工具结果截断逻辑到单一扼流点 `formatToolResultForUI`
+- 2025-07-14: `format-tool-results-in-ui` — 增加内容感知格式化（JSON、代码块），ToolCard 切换为 Markdown 渲染
+- 2026-07-15: `toolcard-compact-spacing` — 修复 CSS 层叠层冲突导致的内置工具结果间距过大
+- 2026-07-15: `fix-tool-result-rendering` — 修复 ToolCard CSS 继承冲突导致的格式破损，提升截断限制，MCP 原始块启用 Markdown
+
+## 初始设计
+
+工具结果在前端展示存在两条独立的管道（Live 路径和 History 路径），各自实现截断逻辑且不一致。
+
+`unify-tool-result-formatting` 创建了 `src/ui/shared/tool-result-formatter.ts` 作为单一扼流点，`format-tool-results-in-ui` 在此基础上增加了内容感知格式化（JSON pretty-print、bash 代码块包裹）并将 ToolCard 结果体切换为 Markdown 组件渲染。
+
+## 修复记录
+
+### 修复: CSS 层叠层冲突导致间距过大
+- **症状**: 内置工具结果 header 与内容之间有 ~19px 间隙，MCP 工具仅 ~2px
+- **根因**: `.tool-card-body-inner pre` 样式位于 `@layer components`，被 Tailwind `@layer utilities` 的 `p-3` + `my-1` 覆盖
+- **修复**: 移出 `@layer components` 到非层级 CSS；`<pre>` 内联样式迁移为 CSS 类
+
+### 修复: ToolCard 内 Markdown 渲染格式破损
+- **症状**: 内置工具结果 JSON 显示为单行、代码块结构丢失、内容周围大块空白；MCP 工具结果落入 raw block 路径后以纯文本显示无 Markdown 渲染
+- **根因**: `.tool-card-body-inner` 的 `white-space: pre-wrap`、`font-family: monospace`、`color: muted` 等 CSS 属性被子元素 `<Markdown>` 的 `<pre>` 继承，破坏了代码块渲染；`DEFAULT_MAX_CHARS = 600` 截断 pretty-print 后的 JSON 使其不可读；MCP `mcp-raw-block` 使用 `{tool.result}` 而非 `<Markdown>`
+- **修复**: 从 `.tool-card-body-inner` 和 `.mcp-raw-block` 中移除冲突 CSS 属性（保留 padding、border-top、max-height、overflow-y）；MCP raw block 切换为 `<Markdown>` 渲染；`DEFAULT_MAX_CHARS` 从 600 提升至 2000；降低 Markdown `<pre>` margin；提升 `.tool-card-body-inner` `max-height` 至 400px
+
+## 最终状态
+
+`fix-tool-result-rendering` 做了以下修复：
+- 从 `.tool-card-body-inner` 移除 `font-family`、`color`、`white-space`、`font-size`、`line-height`，让 Markdown 组件全权控制文本样式
+- 从 `.mcp-raw-block` 同理移除冲突属性
+- MCP raw block 路径改用 `<Markdown>{tool.result}</Markdown>` 渲染
+- `DEFAULT_MAX_CHARS` 从 600 提升至 2000，避免 pretty-print JSON 被中截断
+- Markdown 组件 `<pre>` margin 从 `my-2` 缩小，消除 ToolCard 内空白
+- `.tool-card-body-inner` `max-height` 从 320px 提升至 400px

--- a/openspec/changes/archive/2026-07-15-fix-tool-result-rendering/design.md
+++ b/openspec/changes/archive/2026-07-15-fix-tool-result-rendering/design.md
@@ -1,0 +1,68 @@
+## Context
+
+The Web UI ToolCard component has two rendering paths for tool results:
+1. **Built-in tools** (non-MCP): results go through `formatToolResultForUI` → `<Markdown>` component
+2. **MCP tools**: JSON results → `RichListItem` cards; non-JSON results → `mcp-raw-block` plain text
+
+A previous fix (whole `<Markdown>` instead of line-by-line split) was applied, but the rendering is still broken because the CSS container `.tool-card-body-inner` sets `font-family: monospace`, `color: muted`, `white-space: pre-wrap` which are **inherited** by the `<Markdown>` component's `<pre>` and `<p>` elements. This causes:
+- Code blocks to wrap instead of scroll (inherited `pre-wrap`)
+- All text to appear muted gray (inherited `color`)
+- All text to appear monospace (inherited `font-family`)
+- JSON structure lost when `pre-wrap` collapses pretty-printed newlines into wrapping
+
+Additionally, `DEFAULT_MAX_CHARS = 600` in `formatToolResultForUI` truncates pretty-printed JSON mid-object, and MCP `mcp-raw-block` uses `{tool.result}` (plain text) instead of `<Markdown>`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Built-in tool results render with proper code blocks (horizontal scroll, correct font/color)
+- MCP non-JSON tool results render as Markdown (headings, lists, code blocks, inline code)
+- JSON tool results are readable (pretty-printed, not truncated mid-object)
+- No blank space inside tool cards
+
+**Non-Goals:**
+- Changing the rich list rendering for MCP JSON results (already works well)
+- Adding syntax highlighting to code blocks (ReactMarkdown doesn't support this without additional plugins)
+- Changing the tool card expand/collapse interaction
+- Changing the `formatToolResultForUI` tool-specific formatting logic (bash→sh, grep→json, etc.)
+
+## Decisions
+
+### Decision 1: Remove conflicting CSS properties from container, let Markdown own styling
+
+**Rationale**: The `<Markdown>` component already has custom `pre`, `code`, and `p` overrides with proper styling. The container's CSS properties were designed for the old line-by-line plain text rendering and are now harmful when Markdown handles rendering.
+
+**Alternative considered**: Override `white-space: pre` on the Markdown component's `<pre>` element directly. Rejected because it only fixes one symptom — the `font-family`, `color`, and `font-size` conflicts would remain.
+
+**Properties removed from `.tool-card-body-inner`**: `font-family`, `font-size`, `line-height`, `color`, `white-space`, `word-break`
+**Properties kept**: `padding`, `border-top`, `margin-top`, `max-height`, `overflow-y`
+
+### Decision 2: MCP raw block uses `<Markdown>` instead of plain text
+
+**Rationale**: MCP tools can return Markdown-formatted text (e.g. file contents from `get_file`). Rendering as plain text shows literal `\n` and loses all formatting. Using `<Markdown>` brings parity with built-in tools.
+
+**Alternative considered**: Keep plain text but add `white-space: pre-wrap` to preserve newlines. Rejected because it doesn't render headings, code blocks, or inline code — MCP results that contain Markdown would look raw.
+
+### Decision 3: Raise `DEFAULT_MAX_CHARS` from 600 to 2000
+
+**Rationale**: Pretty-printed JSON with 2-space indentation easily exceeds 600 chars for moderate objects. 2000 chars allows most tool results to display fully without truncation. The truncation hint (`… (N more chars)`) is preserved for results exceeding the limit.
+
+**Alternative considered**: Remove truncation entirely. Rejected because very large tool results (e.g. `read_file` on a 10k-line file) would create unmanageable DOM size.
+
+### Decision 4: Reduce `<pre>` margin from `my-2` (8px) to 4px
+
+**Rationale**: Inside a compact tool card, 16px total vertical margin on `<pre>` creates visible blank space. 4px (8px total) is enough visual separation without wasting space.
+
+### Decision 5: Raise `.tool-card-body-inner` max-height from 320px to 400px
+
+**Rationale**: With the larger char limit (2000), results may be taller. 400px provides headroom while still scrolling for very long results.
+
+## Risks / Trade-offs
+
+- **[Risk] Removing `white-space: pre-wrap` from container may affect non-Markdown text** → Mitigation: The built-in tool path now exclusively uses `<Markdown>`, which handles its own whitespace. No plain text is rendered directly in `.tool-card-body-inner`.
+
+- **[Risk] MCP raw block with Markdown may render unexpected content** → Mitigation: MCP results that are pure text will render as paragraphs, which is acceptable. The `RichListItem` path is unchanged for JSON results.
+
+- **[Risk] Larger char limit may increase DOM size** → Mitigation: 2000 chars is still bounded; the `max-height: 400px` + `overflow-y: auto` ensures the card doesn't grow unbounded.
+
+- **[Trade-off] No syntax highlighting** → Code blocks render as plain monospace text without token coloring. Acceptable — adding a syntax highlighter (e.g. `react-syntax-highlighter`) is a separate concern.

--- a/openspec/changes/archive/2026-07-15-fix-tool-result-rendering/proposal.md
+++ b/openspec/changes/archive/2026-07-15-fix-tool-result-rendering/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+Web UI ToolCard renders built-in tool results with broken formatting: JSON appears as a single unbroken line, code blocks lose their structure, and large blank space appears around content. MCP tool results that fall through to the raw block path render as plain text without Markdown. Root cause: CSS properties on `.tool-card-body-inner` (`white-space: pre-wrap`, `font-family: monospace`, `color: muted`) are inherited by the `<Markdown>` component's `<pre>` elements, breaking code block rendering. Additionally, `DEFAULT_MAX_CHARS = 600` truncates pretty-printed JSON mid-object, and MCP `mcp-raw-block` uses `{tool.result}` instead of `<Markdown>`.
+
+## What Changes
+
+- **Strip conflicting CSS from `.tool-card-body-inner`**: Remove `font-family`, `color`, `white-space`, `font-size`, `line-height` — let the `<Markdown>` component own all text styling. Keep `padding`, `border-top`, `max-height`, `overflow-y`.
+- **Strip conflicting CSS from `.mcp-raw-block`**: Same cleanup — remove `font-family`, `color`, `white-space`, `word-break`. Let Markdown handle rendering.
+- **MCP raw block uses `<Markdown>`**: Change `{tool.result}` to `<Markdown>{tool.result}</Markdown>` so MCP text results get headings, lists, code blocks, and inline code rendering.
+- **Raise `DEFAULT_MAX_CHARS` from 600 to 2000**: 600 chars is too small for pretty-printed JSON; mid-object truncation makes output unreadable.
+- **Reduce `<pre>` margin in Markdown component**: Change `my-2` (8px top + 8px bottom) to a smaller value to eliminate blank space inside tool cards.
+- **Raise `.tool-card-body-inner` `max-height` from 320px to 400px**: Accommodate the larger char limit without excessive truncation.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `tool-result-content-rendering`: Truncation limit changes from 600 to 2000 chars; MCP raw block rendering changes from plain text to Markdown; CSS requirements for `.tool-card-body-inner` and `.mcp-raw-block` updated to remove conflicting properties.
+
+## Impact
+
+- `web/src/index.css` — `.tool-card-body-inner` and `.mcp-raw-block` CSS rules
+- `web/src/components/ToolCard.tsx` — MCP raw block rendering path
+- `web/src/components/Markdown.tsx` — `<pre>` margin adjustment
+- `src/ui/shared/tool-result-formatter.ts` — `DEFAULT_MAX_CHARS` constant
+- No API or protocol changes; no breaking changes to external consumers

--- a/openspec/changes/archive/2026-07-15-fix-tool-result-rendering/prototype.md
+++ b/openspec/changes/archive/2026-07-15-fix-tool-result-rendering/prototype.md
@@ -1,0 +1,3 @@
+## Prototype Status
+
+No prototype needed — this change fixes tool result rendering logic in the TUI/Web backend. It does not introduce new UI components, pages, or visual interaction patterns.

--- a/openspec/changes/archive/2026-07-15-fix-tool-result-rendering/specs/tool-result-content-rendering/spec.md
+++ b/openspec/changes/archive/2026-07-15-fix-tool-result-rendering/specs/tool-result-content-rendering/spec.md
@@ -1,7 +1,5 @@
-## Purpose
+## MODIFIED Requirements
 
-Defines how tool results are formatted for display in the frontend, ensuring content-aware rendering with proper code fences, MCP rich lists, and visual distinction.
-## Requirements
 ### Requirement: Content-aware tool result formatting
 `formatToolResultForUI` SHALL detect the content type of tool result text and apply appropriate formatting before it reaches the frontend. The function SHALL produce markdown-ready output so that ToolCard can render it through the shared `<Markdown>` component. The default truncation limit SHALL be 2000 characters.
 
@@ -72,24 +70,6 @@ The ToolCard component SHALL render the entire formatted tool result as a single
 - **THEN** the `<pre>` element SHALL have a vertical margin no greater than 4px top and 4px bottom
 - **AND** the container padding SHALL not exceed 10px top and 12px bottom
 
-### Requirement: MCP tool result rich list rendering
-When a tool with `mcp__` prefix returns a result that is valid JSON (starts with `{` or `[`), the ToolCard SHALL render the result as a `.mcp-rich-list` component instead of a standard code-fenced block. The rich list SHALL display structured results as vertically stacked cards with title, score, URL, content, and metadata. The `.mcp-rich-list` SHALL NOT have a `border-top` — visual separation relies on background contrast.
-
-#### Scenario: MCP JSON array renders as rich list
-- **WHEN** an MCP tool result is a JSON array
-- **THEN** ToolCard SHALL render `<div class="mcp-rich-list">` with one `<div class="mcp-rich-item">` per array element
-- **AND** each item SHALL attempt to extract `title`, `score`, `url`, `content` fields from the JSON object
-- **AND** unrecognized fields SHALL be ignored
-
-#### Scenario: MCP JSON object renders as rich list
-- **WHEN** an MCP tool result is a JSON object containing a search results-like structure
-- **THEN** ToolCard SHALL attempt to render it as a rich list using the same field extraction logic
-
-#### Scenario: Rich list compact spacing
-- **WHEN** a `.mcp-rich-list` renders inside a ToolCard
-- **THEN** the list SHALL NOT have a `border-top` property
-- **AND** visual separation from the header SHALL rely on background contrast
-
 ### Requirement: MCP tool result raw block rendering
 When an MCP tool result is not valid JSON, the ToolCard SHALL render the result through the `<Markdown>` component so that headings, lists, code blocks, and inline code are properly formatted. The container element (`.mcp-raw-block`) SHALL NOT set `font-family`, `color`, `white-space`, or `word-break` properties — these SHALL be owned by the `<Markdown>` component.
 
@@ -107,17 +87,3 @@ When an MCP tool result is not valid JSON, the ToolCard SHALL render the result 
 - **WHEN** the `.mcp-raw-block` container renders `<Markdown>` content
 - **THEN** the container SHALL NOT set `font-family`, `color`, `white-space`, or `word-break`
 - **AND** the `<Markdown>` component's `pre`, `code`, and `p` overrides SHALL control all text styling
-
-### Requirement: MCP tool card visual distinction
-Tool cards for MCP tools (name starts with `mcp__`) SHALL receive the `.mcp` CSS class to apply a left accent border and display an "MCP" badge in the header.
-
-#### Scenario: MCP class applied to tool card
-- **WHEN** a tool card for `mcp__github` or any `mcp__*` tool renders
-- **THEN** the card `<div>` SHALL have both `.tool-card` and `.mcp` classes
-- **AND** the header SHALL include a `.mcp-badge` element
-
-#### Scenario: Non-MCP tools not affected
-- **WHEN** a tool card for `read_file`, `bash`, `edit`, or any non-`mcp__` tool renders
-- **THEN** the card SHALL NOT have the `.mcp` class
-- **AND** the header SHALL NOT include an MCP badge
-

--- a/openspec/changes/archive/2026-07-15-fix-tool-result-rendering/tasks.md
+++ b/openspec/changes/archive/2026-07-15-fix-tool-result-rendering/tasks.md
@@ -1,0 +1,22 @@
+## 1. CSS Cleanup — Remove Conflicting Properties
+
+- [x] 1.1 In `web/src/index.css`, strip `font-family`, `font-size`, `line-height`, `color`, `white-space`, `word-break` from `.tool-card-body-inner`. Keep `padding`, `border-top`, `margin-top`, `max-height`, `overflow-y`. Change `max-height` from 320px to 400px.
+- [x] 1.2 In `web/src/index.css`, strip `font-family`, `font-size`, `line-height`, `color`, `white-space`, `word-break` from `.mcp-raw-block`. Keep `padding`, `border-top`, `max-height`, `overflow-y`, `background`.
+
+## 2. Markdown Component — Reduce Pre Margin
+
+- [x] 2.1 In `web/src/components/Markdown.tsx`, change the `pre` override's className from `p-3 overflow-x-auto text-xs my-2` to `p-3 overflow-x-auto text-xs my-1` (reduces vertical margin from 8px to 4px).
+
+## 3. ToolCard — MCP Raw Block Uses Markdown
+
+- [x] 3.1 In `web/src/components/ToolCard.tsx`, change the MCP raw block rendering from `{tool.result}` (plain text) to `<Markdown className="text-xs">{tool.result}</Markdown>`.
+
+## 4. Tool Result Formatter — Raise Char Limit
+
+- [x] 4.1 In `src/ui/shared/tool-result-formatter.ts`, change `DEFAULT_MAX_CHARS` from 600 to 2000.
+
+## 5. Build & Verify
+
+- [x] 5.1 Run `npm run typecheck` — must pass with zero errors.
+- [x] 5.2 Run `npm run build` — must complete successfully.
+- [ ] 5.3 Manually verify in browser: built-in tool JSON results render as pretty-printed code blocks with horizontal scroll; MCP text results render as Markdown; no large blank space inside tool cards.

--- a/openspec/changes/archive/2026-07-15-fix-tui-file-drag-drop/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-15-fix-tui-file-drag-drop/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-plus
+created: 2026-07-15

--- a/openspec/changes/archive/2026-07-15-fix-tui-file-drag-drop/consolidate.md
+++ b/openspec/changes/archive/2026-07-15-fix-tui-file-drag-drop/consolidate.md
@@ -1,0 +1,85 @@
+## 变更综述
+
+文件拖拽功能的最终形态演进：从 Web UI 基础拖拽 → `[file:xxx]` 格式协议 → 大小限制 + 缓存 → 二进制编码修复 → 到最后一次全面重构：TUI 非图片文件改为路径引用（不预读内容）、Web UI 图片浏览器端压缩、项目文件自动 @path 匹配、config 驱动的文件大小限制、Settings 上传缓存管理。这个变更修正了拖拽功能中所有的设计缺陷，建立了完整的 Web/TUI 双端一致的文件处理架构。
+
+## 变更时间线
+
+- 2026-07-08: web-drag-drop-files — Web UI 支持拖拽文件插入 @path，FileAttachment 类型、文件芯片、双向同步
+- 2026-07-08: drag-drop-file-attachments — [file:xxx] 格式协议 + FileTracker，统一 Web/TUI 文件追踪
+- 2026-07-08: fix-at-image-size-limit — 修复 @ 引用图片时的 50KB 限制
+- 2026-07-15: fix-file-upload-cache — 解除文件大小限制（50KB→10MB），新增上传缓存展示与清理
+- 2026-07-15: fix-upload-binary-encoding — 修复二进制文件上传编码损坏（readAsText → base64）
+- 2026-07-15: fix-tui-file-drag-drop — TUI 路径引用、Web 图片压缩、@path 匹配、config 驱动限制
+
+## 初始设计
+
+**问题**：Web UI 用户无法拖拽文件——最直观的交互方式完全缺失。
+
+**方案**：Web UI 接受拖拽，readAsText() 读内容 → 上传到 .dscode/uploads/ → 注入 prompt。引入 FileAttachment、文件芯片、双向同步。
+
+## 变更记录
+
+### 变更: [file:xxx] 格式协议 + FileTracker
+
+- **触发**: 用户拖入文件后无法在编辑器中看到文件与提示词的关联
+- **改动**: 引入 [file:displayPath] 纯文本标记协议，FileTracker 统一 Web/TUI 文件追踪
+- **影响**: Web UI handleDrop 改为注册 tracker + 芯片；TUI 新增拖拽处理和 attachment bar
+
+### 变更: 图片 @ 引用大小限制修复
+
+- **触发**: resolveAtFileRefs 对所有文件统一施加 50KB 限制，>50KB 图片被静默跳过
+- **改动**: 移除图片的 maxFileSize，新增 maxImageSize（20MB），图片不计入 maxTotalSize
+
+### 变更: 解除文件大小限制 + 缓存管理
+
+- **触发**: 50KB/200KB 硬限制静默丢弃；上传缓存无限增长
+- **改动**: 单文件 50KB→10MB，总计 200KB→50MB，超出 toast；Settings Cache 区块；session 删除清理
+
+### 变更: 二进制文件上传编码修复
+
+- **触发**: readAsText() 导致 PDF/DOCX 等二进制文件 UTF-8 解码损坏
+- **改动**: 前端 readAsArrayBuffer() → base64，后端 Buffer.from(content, "base64") 解码
+
+## 修复记录
+
+### 修复: TUI 文件拖拽路径引用 + Web 全面重构
+
+- **症状**: 
+  - TUI 拖放非图片文件时 resolveFileRefs 预读全文注入 prompt，浪费 context window
+  - Web UI 大图片（>500KB）传输中被截断，vision 降级 OCR 产生乱码
+  - Web UI 文件大小限制硬编码 50KB，超限静默跳过无提示
+  - 项目文件被完整上传到 temp 目录而非 @path 引用
+- **根因**: 
+  - TUI 端 resolveFileRefs 对图片和非图片文件一视同仁，全部读取内容
+  - Web UI 图片未经浏览器端压缩，原始 base64 过大导致 WebSocket 传输截断
+  - MessageInput 中 MAX_FILE_SIZE 硬编码而非 config 驱动
+  - 缺少项目文件匹配逻辑，所有文件都走上传路径
+- **修复**: 
+  - TUI 非图片文件：注入绝对路径引用 `📁 Attached files:\n- \`/abs/path/file\``，不调 resolveFileRefs
+  - TUI 图片文件：保持现有 ImagePipeline 行为
+  - Web UI 图片上传：Canvas resize max 480px → JPEG 85% 浏览器端压缩
+  - Web UI 拖放项目文件：搜索项目目录，自动匹配为 @path 引用，零传输
+  - Web UI 文件大小限制：从硬编码改为 config 驱动（默认 10MB/50MB），超限 toast
+  - Settings 面板：上传缓存统计 + 一键清空按钮
+  - web-backend.ts：修复重复 fileRefs split block（导致路径注入两次）
+
+## 最终状态
+
+**问题**：TUI 非图片拖放浪费 context window，Web 图片传输截断，文件大小限制僵化，项目文件被重复上传。
+
+**方案**：
+- TUI 非图片 → 路径引用，不预读内容，Agent 按需 read_file
+- TUI 图片 → 保持 ImagePipeline（不变）
+- Web 图片 → 浏览器端 Canvas 压缩（max 480px JPEG 85%）再传输
+- Web 项目文件 → 自动 @path 匹配，零传输
+- Web 外部文件 → 上传到 .dscode/uploads/，base64 编码
+- 文件大小限制 → config 驱动，默认 10MB/50MB
+- Settings → 上传缓存统计 + 清空
+
+**新增能力**：
+- `tui-file-drop-path-ref`: TUI 非图片文件注入路径引用而非内容
+- `web-upload-temp-file`: Web 文件上传、@path 匹配、config 限制、toast 反馈
+- `web-image-compress`: Web 图片浏览器端压缩
+
+**修改能力**：
+- `file-tracker`: resolveFileRefs 按文件类型分流（图片走管线，非图片走路径注入）

--- a/openspec/changes/archive/2026-07-15-fix-tui-file-drag-drop/design.md
+++ b/openspec/changes/archive/2026-07-15-fix-tui-file-drag-drop/design.md
@@ -1,0 +1,173 @@
+## Context
+
+当前 `handleSubmit` 中 `hasFiles` 分支对所有拖放文件（图片和非图片）统一调用 `resolveFileRefs`，该函数读取文件内容并注入 prompt。非图片文件的预读浪费 context window——Agent 只需知道绝对路径，可自行按需 `read_file`。
+
+图片文件仍需走 `resolveFileRefs` 提取 base64 后进入 `ImagePipeline`。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 非图片拖放文件：Agent prompt 中只注入绝对路径引用，不预读内容
+- 图片拖放文件：保持现有行为不变（进入 ImagePipeline）
+- TUI prompt 框的 `[file:xxx]` 标记和 attachment bar 保持不变
+- Web UI 对应路径同步修改
+
+**Non-Goals:**
+- 不改变 FileTracker 的存储逻辑
+- 不改变 ImagePipeline 的处理流程
+- 不改变 paste/drop 事件的检测逻辑
+
+## Decisions
+
+### Decision 1: 在 handleSubmit 中按文件类型分流
+
+`handleSubmit` 的 `hasFiles` 分支当前逻辑：
+
+```
+fileRefs = tracker.drain()
+for all fileRefs:
+    resolveFileRefs(projectPath, fileRefs)  → 读内容 + 提取图片
+    text += refsResolved.text
+    images += refsResolved.images
+```
+
+改为：
+
+```
+fileRefs = tracker.drain()
+imageRefs = fileRefs.filter(isImagePath)
+nonImageRefs = fileRefs.filter(f => !isImagePath(f))
+
+// 图片：走现有 resolveFileRefs
+if imageRefs.length > 0:
+    resolveFileRefs(projectPath, imageRefs)  → 只有图片
+    images += refsResolved.images
+
+// 非图片：只注入路径引用
+if nonImageRefs.length > 0:
+    pathLines = nonImageRefs.map(f => `- \`${f}\``).join('\n')
+    text += '\n\n📁 Attached files:\n' + pathLines
+```
+
+**替代方案考虑**：
+- 方案 B：修改 `resolveFileRefs` 内部逻辑，加 `skipContentRead` 参数。→ 污染通用函数，不选。
+- 方案 C：新建 `resolveFilePaths` 只处理路径。→ 过度设计，改动量相似但多一个函数。
+
+**选择方案 A 的原因**：改动集中在 `handleSubmit` 一处，逻辑清晰，不影响现有 `resolveFileRefs` 的语义。
+
+### Decision 2: 图片检测使用现有 `isImagePath`
+
+复用 `at-file-resolver.ts` 中已导出的 `isImagePath`（或内部使用的同逻辑）。当前 `isImagePath` 匹配 `.png/.jpg/.jpeg/.gif/.webp/.bmp`。
+
+如果 `isImagePath` 未导出，则在 `tui-app.ts` 中内联一个简单的扩展名检测（不需要引入整个 at-file-resolver 的复杂度）。
+
+### Decision 3: 路径引用格式
+
+格式选择：`📁 Attached files:\n- \`/abs/path/file.ts\``
+
+- 使用 emoji `📁` 作为视觉标记，与现有系统风格一致
+- 反引号包裹路径，符合 markdown 代码引用风格
+- 每条路径一行，方便 Agent 提取
+
+**替代方案**：用 `[Attached: /abs/path]` 格式 → 与 `[file:xxx]` 标记语义冲突，不选。
+
+### Decision 4: Web 端同步修改
+
+`web-backend.ts` 中对应的 `hasFiles` 分支（约 line 505-530）与 TUI 端逻辑一致，需要同步修改。~~**注意**：此决策基于「Web 端也能获取绝对路径」的错误假设，已被 Decision 5 取代。Web 端实际需要不同的处理方式。~~
+
+### Decision 5: Web 端拖放改用文件上传 + 临时路径
+
+**问题**：Decision 4 假设 Web 端和 TUI 端可以复用同一套「注入绝对路径」逻辑，但这对 Web 端不成立。
+
+- 浏览器安全沙箱禁止网页获取拖放文件的绝对路径（`File.path` 在非 Electron 环境下恒为 `undefined`）
+- Web 端的 `fileRefs` 实际传入的是裸文件名（`file.name` fallback），而非绝对路径
+- 导致 `resolveFileRefs` 无法在服务端定位文件（`not_found`），图片内容无法提取，非图片路径引用也无效
+
+**决策**：Web 端拖放采用与 paste 相似的机制——在浏览器端用 `FileReader` 读取文件内容后传到服务端。
+
+```
+Web UI drop 流程：
+
+  浏览器端                         服务端
+  ────────                        ──────
+  FileReader.readAsDataURL()      
+  → 图片：base64 → images[]       和 paste 行为一致，直接进入 ImagePipeline
+  
+  FileReader.readAsText()         
+  → 非图片：文本内容 → WebSocket   
+                                  写入临时文件：
+                                  .dscode/uploads/<session>/<timestamp>-<filename>
+                                  
+                                  注入 prompt：
+                                  📁 Attached files:
+                                  - `/project/.dscode/uploads/.../config.json`
+                                  
+                                  Agent 可通过 read_file 读取 ✅
+```
+
+**与 TUI 端的差异**：
+| 方面 | TUI | Web UI |
+|------|-----|--------|
+| 路径来源 | OS 原生，绝对路径 | 服务端生成的临时路径 |
+| 图片 | resolveFileRefs 从磁盘读 | FileReader 浏览器读 |
+| 非图片 | 只注入原始路径，不读内容 | 上传内容到临时文件，注入临时路径 |
+| Agent 行为 | read_file 读原始文件 | read_file 读临时副本 |
+
+**临时文件管理**：
+- 路径：`.dscode/uploads/<session-id>/<timestamp>-<original-name>`
+- 跳过已存在的临时文件（timestamp 保证唯一性）
+- 会话结束时清理临时目录（或在 compaction 时清理）
+
+**大小限制**：沿用 `atFile` 配置中的 `maxFileSize` / `maxTotalSize`，在浏览器端做预检查。
+
+## Risks / Trade-offs
+
+- **[风险] `isImagePath` 扩展名白名单可能漏掉新格式** → 低风险。白名单已覆盖主流图片格式。新增格式可后续扩展。
+- **[风险] Agent 拿到多个绝对路径后可能一次 `read_file` 多个大文件** → 这是 Agent 的自主决策，与现有 `@path` 引用行为一致，非新引入风险。
+- **[Trade-off] 非图片文件的文件大小检查被跳过** → 当前 `resolveFileRefs` 有 maxFileSize/maxTotalSize 限制。跳过内容读取后，这些限制不再适用——但 Agent 自己调用 `read_file` 时仍受工具层限制保护。
+
+- **[Trade-off] 外部文件必须复制到 temp 目录，占用磁盘空间** → 浏览器沙箱禁止获取绝对路径，无法用 symlink。但项目文件走 @path 匹配不占空间，外部文件 session 结束时清理，实际影响极小。
+
+### Decision 6: 拖入文件优先尝试项目内 @path 匹配
+
+**问题**：当前 handleDrop 对所有非图片文件一律读取 content → temp file。但实际上很多拖入的文件就在项目目录里，如果能匹配到项目路径，直接注入 `@path` 引用即可——零传输、零磁盘开销、零大小限制，和 TUI 行为一致。
+
+**决策**：在 handleDrop 中增加一层"项目文件匹配"路由：
+
+```
+handleDrop(files):
+  for each file:
+    if isImage(file.type):
+      → fileToImageAttachment → compress → images state  (不变)
+    else:
+      → 用 file.name 搜索项目文件列表 (复用 file_list 命令)
+      
+      匹配 1 个 → 注入 @path (零传输,零磁盘)
+      匹配 N 个 → 弹 picker (复用 showFileMenu) → 用户选 → 注入 @path
+      匹配 0 个 → 外部文件 → 现有 upload-to-temp 流程
+                     → 大小检查 (config 驱动,默认 10MB)
+                     → toast 提示超限
+```
+
+**与现有 spec 的关系**：这是对 `web-upload-temp-file` spec 的扩展——upload-to-temp 变成了 fallback 路径，而非唯一路径。
+
+**UI 复用**：文件选择 picker 复用 `MessageInput` 中已有的 `showFileMenu` 组件，不需要新建 UI。
+
+### Decision 7: 文件大小限制从 config 驱动
+
+**问题**：当前硬编码 `MAX_FILE_SIZE = 50KB`（太保守），且对图片和非图片不对称（图片无限制）。
+
+**决策**：
+- 服务端通过 `config` / `ready` 事件下发 `maxFileSize` 和 `maxTotalSize`
+- 默认值：`maxFileSize = 10MB`，`maxTotalSize = 50MB`（只对走 upload-to-temp 的外部文件生效）
+- 图片不设大小限制（走 compressImage 已有压缩保护）
+- 项目 @path 文件不设大小限制（零传输）
+- 超限文件被跳过时**必须显示 toast 警告**，不能静默丢弃
+
+### Decision 8: Settings 面板增加缓存管理
+
+**决策**：
+- Settings 面板底部增加 "Upload Cache" 区域
+- 显示当前缓存状态：文件数 + 总大小（服务端启动时扫描，`upload_stats` 事件推送）
+- 提供 "Clear Upload Cache" 按钮
+- 点击发送 `{ type: "clear_uploads" }` → 服务端删除 `.dscode/uploads/` 全部内容 → 返回统计 → toast 反馈

--- a/openspec/changes/archive/2026-07-15-fix-tui-file-drag-drop/proposal.md
+++ b/openspec/changes/archive/2026-07-15-fix-tui-file-drag-drop/proposal.md
@@ -1,0 +1,38 @@
+## Why
+
+TUI 拖放非图片文件时，`resolveFileRefs` 会读取文件全文并注入到 prompt 中，造成 context window 大量浪费。Agent 真正需要的是文件的**绝对路径引用**，而非预读的文件内容——Agent 可以自行调用 `read_file` 按需读取。此前 session 00MRL886 的修复尝试停止读取内容，但引入了新 bug：Agent 连绝对路径也感知不到了。
+
+测试中还发现：大图片（>500KB）在 Web UI 传输过程中被截断，导致 vision model 调用失败、静默降级到 OCR。根因是浏览器端未压缩，原始分辨率 base64 过大（871KB 文件 → ~1.16MB base64），在 WebSocket 或终端协议传输中丢失数据。
+Web UI 拖入非图片 PDF 等文件时无反应。根因是硬编码 50KB 限制对所有非图片文件生效（图片无限制），且超限文件被静默跳过无提示。此外，外部文件被复制到 temp 目录后缺乏手动清理入口。
+
+## What Changes
+
+- **非图片拖放文件**：不再调用 `resolveFileRefs` 读取内容，改为在 prompt 中注入清晰的绝对路径引用行
+- **图片拖放文件**：保持现有行为，通过 `resolveFileRefs` 提取 base64 后进入 ImagePipeline（不变）
+- **TUI prompt 框**：保持显示 `[file:basename]` 简洁标记（不变）
+- **Web UI 图片上传**：浏览器端先压缩（Canvas resize max 480px → JPEG 85%），再发送（新增）
+- **Web UI 拖放项目文件**：自动匹配为 `@path` 引用，零传输零磁盘（新增）
+- **Web UI 文件大小限制**：从硬编码 50KB 改为 config 驱动（默认 10MB），超限 toast 提示（修复）
+- **Settings 缓存管理**：面板显示上传缓存统计，提供一键清空按钮（新增）
+- **Web UI 图片上传**：浏览器端先压缩（Canvas resize max 480px → JPEG 85%），再发送（新增）
+
+## Capabilities
+
+- `web-upload-temp-file`: Web 拖放非图片文件上传到临时目录（扩展：增加 @path 匹配、config 驱动限制、toast 反馈）
+- `tui-file-drop-path-ref`: TUI 拖放非图片文件时，Agent prompt 中注入绝对路径引用而非文件内容
+- `web-drop-project-match`: Web 拖入项目文件时自动匹配为 @path 引用
+- `web-settings-cache`: Settings 面板显示并管理上传缓存
+- `web-image-compress`: Web UI 所有图片（paste + drag-drop）在浏览器端压缩后再传输，防止大图截断导致 vision 降级 OCR
+
+### Modified Capabilities
+- `file-tracker`: `resolveFileRefs` 的调用方式变更——由 `handleSubmit` 按文件类型分流，图片走 `resolveFileRefs`，非图片走纯路径注入
+
+## Impact
+
+- `web/src/components/MessageInput.tsx` — `handleDrop` 增加项目文件匹配路由、config 驱动大小检查、toast 反馈
+- `web/src/components/Sidebar.tsx` — `SettingsPanel` 增加上传缓存区域
+- `web/src/components/App.tsx` — 处理 `upload_stats` / `clear_uploads` 事件
+- `src/ui/shared/types.ts` — 新增 `upload_stats` / `clear_uploads` 协议类型
+- `src/ui/web/web-backend.ts` — 对应 Web 端的 `hasFiles` 分支同样需要修改
+- `src/utils/at-file-resolver.ts` — 无需修改（`resolveFileRefs` 保留给图片文件使用）
+- `web/src/components/MessageInput.tsx` — `fileToImageAttachment` 增加 Canvas 压缩步骤

--- a/openspec/changes/archive/2026-07-15-fix-tui-file-drag-drop/prototype.md
+++ b/openspec/changes/archive/2026-07-15-fix-tui-file-drag-drop/prototype.md
@@ -1,0 +1,86 @@
+## Visual Direction
+
+无需 UI 视觉变化——此变更仅影响 Agent 收到的 prompt 文本格式。TUI prompt 框的 `[file:xxx]` 标记保持不变。
+
+## Before / After Comparison
+
+### 拖入 1 个图片 + 2 个非图片文件
+
+**Before (当前 — 浪费 context window):**
+
+```
+[file:photo.png] [file:config.json] [file:types.ts]
+
+用户说: 帮我看看这些文件
+
+`/Users/xxx/Desktop/photo.png`:
+```png
+iVBORw0KGgo... (base64 数据, 可能数 KB)
+```
+
+`/Users/xxx/Desktop/config.json`:
+```json
+{
+  "settings": { ... 500 lines of JSON ... }
+}
+```
+
+`/Users/xxx/Desktop/types.ts`:
+```typescript
+export interface User { ... 200 lines of types ... }
+```
+```
+
+→ Agent 拿到大量不需要预读的文件内容
+→ 如果文件很大（如几百行的 JSON/TS），直接占满 context window
+
+**After (修复后 — 只有路径引用):**
+
+```
+[file:photo.png] [file:config.json] [file:types.ts]
+
+用户说: 帮我看看这些文件
+
+📁 Attached files:
+- `/Users/xxx/Desktop/config.json`
+- `/Users/xxx/Desktop/types.ts`
+
+<image_description>
+一张截图，显示了一个配置面板...
+</image_description>
+```
+
+→ 图片经过 ImagePipeline，Agent 拿到文字描述 ✅
+→ 非图片只有清晰路径引用，Agent 可以 `read_file` 按需读取 ✅
+→ Context window 节省大量空间 ✅
+
+## Interaction Flow
+
+```
+拖入文件
+    │
+    ├── 图片 (.png/.jpg/.webp/.gif/.bmp)
+    │      │
+    │      ├── TUI prompt: [file:photo.png]  (不变)
+    │      ├── Attachment bar: 📷 1 image  (不变)
+    │      └── Prompt: resolveFileRefs → ImageContent[] → ImagePipeline
+    │             → <image_description> 文本描述
+    │
+    └── 非图片 (其他所有扩展名)
+           │
+           ├── TUI prompt: [file:config.json]  (不变)
+           ├── Attachment bar: 📎 config.json  (不变)
+           └── Prompt: 纯路径引用
+                  → `📁 /abs/path/config.json`
+```
+
+## Design References
+
+- `file-tracker` spec：已定义 FileTracker 的绝对路径存储和 display path 逻辑
+- `tui-attachment-bar-render` spec：已定义附件栏渲染行为
+- `image-pipeline` spec：已定义 ImagePipeline 处理流程
+- 拖放输入的粘贴检测在 `handlePasteImage` 中，无需修改
+
+## Accessibility Notes
+
+无 UI 交互变更。TUI 编辑框中的 `[file:xxx]` 标记保持现有格式（basename only），不影响可读性。

--- a/openspec/changes/archive/2026-07-15-fix-tui-file-drag-drop/specs/file-tracker/spec.md
+++ b/openspec/changes/archive/2026-07-15-fix-tui-file-drag-drop/specs/file-tracker/spec.md
@@ -1,0 +1,56 @@
+## MODIFIED Requirements
+
+### Requirement: submit with fileRefs passes fileRefs independently from text
+When the user submits a message, the system SHALL pass tracked file paths as a separate `fileRefs` array. Image files SHALL be processed through `resolveFileRefs` and enter ImagePipeline. Non-image files SHALL be injected as absolute path references into the prompt text without reading file contents.
+
+#### Scenario: Web UI submit with uploaded files (non-image)
+- **WHEN** user drags non-image files into the Web UI and submits
+- **THEN** the WebSocket command SHALL include `uploadedFiles` array with `{ name, content }` objects
+- **AND** the `fileRefs` field SHALL NOT be used for web drag-and-drop
+- **AND** the `text` field SHALL contain only the user's typed message text
+
+#### Scenario: Web UI submit with dropped images
+- **WHEN** user drags image files into the Web UI and submits
+- **THEN** the images SHALL be read as base64 via FileReader in the browser
+- **AND** the base64 data SHALL be sent in the `images` field (same as paste behavior)
+- **AND** the image SHALL NOT go through `resolveFileRefs` on the server
+
+#### Scenario: Web backend writes uploaded files to temp directory
+- **WHEN** the Web backend receives `uploadedFiles` in a chat command
+- **THEN** each file SHALL be written to `.dscode/uploads/<session-id>/<timestamp>-<filename>`
+- **AND** the temp paths SHALL be injected into the prompt as `📁 Attached files:\n- \`/project/.dscode/uploads/...\``
+- **AND** the Agent CAN read the files via `read_file` on the temp paths
+
+#### Scenario: Web UI drop with mixed image and non-image files
+- **WHEN** user drags both image and non-image files into the Web UI and submits
+- **THEN** images SHALL go into `images` field as base64
+- **AND** non-images SHALL go into `uploadedFiles` field with content
+- **AND** both SHALL appear in the Agent prompt (images via ImagePipeline, non-images via temp path references)
+
+#### Scenario: TUI submit with fileRefs containing images
+- **WHEN** user presses Enter in the TUI with tracked image files
+- **THEN** the submission SHALL include the image fileRefs from the tracker
+- **AND** the image files SHALL be processed through `resolveFileRefs` and enter ImagePipeline
+- **AND** the editor text content SHALL be preserved as user message text
+
+#### Scenario: TUI submit with fileRefs containing non-image files
+- **WHEN** user presses Enter in the TUI with tracked non-image files
+- **THEN** the absolute paths SHALL be injected into the prompt as path references (e.g., `📁 Attached files:\n- \`/abs/path/file.ts\``)
+- **AND** `resolveFileRefs` SHALL NOT be called for non-image files
+- **AND** the file contents SHALL NOT be read
+
+#### Scenario: TUI submit with mixed image and non-image fileRefs
+- **WHEN** user presses Enter in the TUI with both image and non-image tracked files
+- **THEN** image files SHALL go through `resolveFileRefs` → ImagePipeline
+- **AND** non-image files SHALL be injected as path references only
+- **AND** both image descriptions and path references SHALL appear in the Agent prompt
+
+#### Scenario: Submit with no tracked files
+- **WHEN** user submits a message with no tracked files
+- **THEN** the `fileRefs` field SHALL be omitted or an empty array
+- **AND** behavior SHALL be identical to before this change
+
+#### Scenario: Tracker is drained after submit
+- **WHEN** a message is submitted
+- **THEN** the tracker SHALL be cleared (via `drain()`)
+- **AND** the chips/status line SHALL be cleared

--- a/openspec/changes/archive/2026-07-15-fix-tui-file-drag-drop/specs/tui-file-drop-path-ref/spec.md
+++ b/openspec/changes/archive/2026-07-15-fix-tui-file-drag-drop/specs/tui-file-drop-path-ref/spec.md
@@ -1,0 +1,46 @@
+## ADDED Requirements
+
+> **Scope**: The requirements below apply to TUI drag-and-drop. For Web UI drag-and-drop behavior, see `web-upload-temp-file/spec.md`.
+
+### Requirement: Non-image drag-drop files inject path references only
+When non-image files are attached via drag-and-drop and the user submits the message, the system SHALL inject only absolute path references into the Agent prompt, without reading the file contents.
+
+#### Scenario: Submit with one non-image file
+- **WHEN** user drags `/Users/x/Downloads/config.json` into the TUI and submits with text "check this"
+- **THEN** the Agent prompt SHALL contain `📁 Attached files:\n- \`/Users/x/Downloads/config.json\``
+- **AND** the file content SHALL NOT be read or injected into the prompt
+- **AND** the prompt SHALL also contain the user's text "check this"
+
+#### Scenario: Submit with multiple non-image files
+- **WHEN** user drags `/tmp/a.ts`, `/tmp/b.json`, `/tmp/c.md` into the TUI and submits
+- **THEN** the Agent prompt SHALL contain a path reference for each file on separate lines
+- **AND** no file contents SHALL be read
+
+#### Scenario: Submit with mixed image and non-image files
+- **WHEN** user drags `photo.png`, `config.json`, `types.ts` into the TUI and submits
+- **THEN** the image file (`photo.png`) SHALL be processed through `resolveFileRefs` and enter the ImagePipeline as normal
+- **AND** the non-image files (`config.json`, `types.ts`) SHALL appear as path references only
+- **AND** the path references SHALL use the absolute file path
+
+#### Scenario: Submit with only non-image files and no user text
+- **WHEN** user drags `config.json` into the TUI and submits without typing any text
+- **THEN** the Agent prompt SHALL contain the path reference
+- **AND** the prompt SHALL NOT be empty or rejected
+
+#### Scenario: Non-image file has been deleted since drop
+- **WHEN** user drags a file that was subsequently deleted from disk and submits
+- **THEN** the path reference SHALL still be injected (the path string itself is valid)
+- **AND** the Agent will receive a "not found" error if it attempts to `read_file`
+
+### Requirement: Image drag-drop files continue to use ImagePipeline
+When image files are attached via drag-and-drop, the system SHALL continue to process them through the existing `resolveFileRefs` → ImagePipeline flow, unchanged from current behavior.
+
+#### Scenario: Submit with only image files
+- **WHEN** user drags `photo.png` into the TUI and submits
+- **THEN** the image SHALL be read and processed through ImagePipeline
+- **AND** the Agent prompt SHALL contain the image description (via `<image_description>`)
+
+#### Scenario: Image file with non-native-image-support model
+- **WHEN** user drags `photo.jpg` and the current model does not support native image input
+- **THEN** the image SHALL go through the vision model or OCR fallback as normal
+- **AND** the Agent SHALL NOT receive raw base64 in the prompt

--- a/openspec/changes/archive/2026-07-15-fix-tui-file-drag-drop/specs/web-upload-temp-file/spec.md
+++ b/openspec/changes/archive/2026-07-15-fix-tui-file-drag-drop/specs/web-upload-temp-file/spec.md
@@ -1,0 +1,162 @@
+## ADDED Requirements
+
+### Requirement: Web drag-and-drop uploads file content to server temp directory
+
+When files are dragged-and-dropped into the Web UI, the browser SHALL read the file content via `FileReader` and transmit it to the server. The server SHALL write non-image files to a temporary directory and inject temp paths into the Agent prompt. Image files SHALL be sent as base64 in the `images` field, consistent with paste behavior.
+
+#### Scenario: Drop a single non-image file in Web UI
+- **WHEN** user drags `config.json` into the Web UI and submits with text "check this"
+- **THEN** the browser SHALL read the file content via `FileReader.readAsText()`
+- **AND** the WebSocket chat command SHALL include `uploadedFiles: [{ name: "config.json", content: "<file contents>" }]`
+- **AND** the server SHALL write the content to `.dscode/uploads/<session-id>/<timestamp>-config.json`
+- **AND** the Agent prompt SHALL contain `📁 Attached files:\n- \`<project>/.dscode/uploads/<session-id>/<timestamp>-config.json\``
+- **AND** the Agent CAN read the temp file via `read_file`
+
+#### Scenario: Drop multiple non-image files in Web UI
+- **WHEN** user drags `a.ts`, `b.json`, `c.md` into the Web UI and submits
+- **THEN** all three files SHALL be read and transmitted in `uploadedFiles`
+- **AND** each SHALL be written to a separate temp file with unique timestamp prefix
+- **AND** each temp path SHALL appear in the 📁 Attached files block
+
+#### Scenario: Drop image files in Web UI
+- **WHEN** user drags `photo.png` into the Web UI and submits
+- **THEN** the browser SHALL read the image via `FileReader.readAsDataURL()`
+- **AND** the image base64 SHALL be sent in the `images` field (NOT `fileRefs`)
+- **AND** the image SHALL enter ImagePipeline on the server
+- **AND** the server SHALL NOT call `resolveFileRefs` for browser-dropped images
+
+#### Scenario: Drop mixed image and non-image files in Web UI
+- **WHEN** user drags `photo.png`, `config.json`, `types.ts` into the Web UI and submits
+- **THEN** `photo.png` SHALL be in `images` field as base64
+- **AND** `config.json` and `types.ts` SHALL be in `uploadedFiles` field with content
+- **AND** the image SHALL go through ImagePipeline
+- **AND** the non-image files SHALL be written to temp paths and referenced in prompt
+
+#### Scenario: Drop only non-image files with no user text in Web UI
+- **WHEN** user drags `config.json` into the Web UI and submits without typing any text
+- **THEN** the prompt SHALL contain the temp path reference
+- **AND** the prompt SHALL NOT be empty or rejected
+
+#### Scenario: Non-image file exceeds size limit for upload (no project match)
+- **WHEN** user drags a file exceeding `maxFileSize` (from atFile config)
+- **THEN** the browser SHALL check size before reading and skip the file
+- **AND** a warning toast SHALL be shown to the user
+
+#### Scenario: Total uploaded size exceeds limit in Web UI
+- **WHEN** user drags files whose combined size exceeds `maxTotalSize` (from atFile config)
+- **THEN** the browser SHALL skip files beyond the limit
+- **AND** a warning toast SHALL be shown
+
+#### Scenario: Temp file cleanup on session end
+- **WHEN** a session ends or is compacted
+- **THEN** the `.dscode/uploads/<session-id>/` directory SHALL be cleaned up
+- **AND** temp files from other sessions SHALL NOT be affected
+
+### Requirement: Web UI handleDrop mirrors handlePaste semantics
+
+The drag-and-drop handler in the Web UI (`handleDrop`) SHALL use the same `FileReader`-based approach as `handlePaste`, reading file content in the browser rather than attempting to extract filesystem paths.
+
+#### Scenario: handleDrop reads file content
+- **WHEN** files are dropped into the MessageInput area
+- **THEN** the handler SHALL iterate over `e.dataTransfer.files`
+- **AND** for each image file, SHALL call `fileToImageAttachment()` to get base64
+- **AND** for each non-image file, SHALL call `FileReader.readAsText()` to get content
+- **AND** SHALL NOT attempt to read `(file as any).path`
+
+#### Scenario: handleDrop does not use FileTracker for content
+- **WHEN** files are dropped into the Web UI
+- **THEN** the FileTracker SHALL NOT be used to track dropped files
+- **AND** image base64 data SHALL be stored in the existing `images` state
+- **AND** non-image content SHALL be stored in a new `uploadedFiles` state
+
+### Requirement: ClientCommand protocol supports uploaded file content
+
+The WebSocket `chat` command SHALL support a new `uploadedFiles` field for transmitting file content from browser to server.
+
+#### Scenario: Chat command includes uploadedFiles
+- **WHEN** the Web UI sends a chat command with uploaded non-image files
+- **THEN** the command SHALL include `uploadedFiles: { name: string; content: string }[]`
+- **AND** `content` SHALL be the UTF-8 text content of the file
+- **AND** `name` SHALL be the original filename (for display and temp path generation)
+
+#### Scenario: Chat command without uploaded files
+- **WHEN** the Web UI sends a chat command with no uploaded files
+- **THEN** the `uploadedFiles` field SHALL be omitted or an empty array
+- **AND** behavior SHALL be identical to before this change
+
+### Requirement: Dragged project files resolve as @path references
+
+When a non-image file is dragged into the Web UI and its filename matches a file in the project directory tree, the system SHALL inject it as a `@path` reference rather than reading the file content. This achieves zero-size-limit "link" semantics for project files, matching TUI behavior.
+
+#### Scenario: Single project file — unique name match
+- **WHEN** user drags `config.json` into the Web UI and the project has exactly one file named `config.json` at `src/lib/config.json`
+- **THEN** the browser SHALL search the project file tree for matching files (via the existing `file_list` command)
+- **AND** the file SHALL be injected as `@src/lib/config.json` in the input text
+- **AND** the file content SHALL NOT be read or transmitted
+- **AND** the Agent SHALL receive the @path reference and can `read_file` the original file directly
+
+#### Scenario: Multiple project files with same name — picker fallback
+- **WHEN** user drags `config.json` and the project has `src/config.json` and `tests/config.json`
+- **THEN** a file picker popover SHALL appear (reusing the existing `showFileMenu` UI component)
+- **AND** the user SHALL select one file from the list
+- **AND** the selected file SHALL be injected as `@<selected-path>`
+- **AND** no file content SHALL be read or transmitted
+
+#### Scenario: External file — no project match
+- **WHEN** user drags `desktop-file.pdf` and no project file has that name
+- **THEN** the system SHALL fall back to the existing upload-to-temp-directory flow
+- **AND** the file content SHALL be read and transmitted to the server
+
+#### Scenario: Project file with ambiguous name — user cancels picker
+- **WHEN** user drags a file with multiple project matches and dismisses the picker (Escape or click outside)
+- **THEN** the file SHALL be dropped silently (no upload, no error)
+
+### Requirement: File size limits are config-driven
+
+The drag-and-drop size limits SHALL be driven by server config rather than hardcoded constants. The browser SHALL receive `maxFileSize` and `maxTotalSize` values from the server (via the `config` or `ready` event) and apply them before reading file content.
+
+#### Scenario: Size limits received from server
+- **WHEN** the Web UI connects and receives `config` event
+- **THEN** the config SHALL include `maxFileSize` and `maxTotalSize` values
+- **AND** the browser SHALL use these values for size checks, NOT hardcoded constants
+
+#### Scenario: Non-image file exceeds maxFileSize
+- **WHEN** user drags a non-image file exceeding `maxFileSize` (and the file has no project match)
+- **THEN** the browser SHALL skip the file before reading its content
+- **AND** a warning toast SHALL be shown: "Skipped filename.ext (exceeds X MB limit)"
+
+#### Scenario: Combined upload exceeds maxTotalSize
+- **WHEN** user drags multiple files whose combined size exceeds `maxTotalSize`
+- **THEN** the browser SHALL skip files beyond the limit
+- **AND** a warning toast SHALL indicate how many files were skipped
+
+#### Scenario: Image files are NOT subject to size limits
+- **WHEN** user drags an image file of any size
+- **THEN** the image SHALL be processed through `fileToImageAttachment` → `compressImage` regardless of size
+- **AND** `maxFileSize` / `maxTotalSize` SHALL NOT apply to images
+
+### Requirement: Settings panel shows upload cache info and clear button
+
+The Settings panel in the Web UI sidebar SHALL display information about the upload cache (`.dscode/uploads/`) and provide a button to clear it.
+
+#### Scenario: Display upload cache stats
+- **WHEN** the Settings panel renders
+- **THEN** it SHALL show the current upload cache stats: number of files and total size (e.g., "Uploaded files: 5 files / 2.3 MB")
+- **AND** the stats SHALL be updated when the server sends `upload_stats` events
+
+#### Scenario: Clear upload cache
+- **WHEN** user clicks "Clear Upload Cache" button
+- **THEN** the browser SHALL send `{ type: "clear_uploads" }` to the server
+- **AND** the server SHALL delete all files in `.dscode/uploads/` recursively
+- **AND** the server SHALL respond with `{ type: "upload_stats", files: 0, bytes: 0 }`
+- **AND** a success toast SHALL be shown: "Cleared N files (X MB)"
+- **AND** the displayed stats SHALL update to 0 files / 0 B
+
+#### Scenario: Clear empty cache
+- **WHEN** user clicks "Clear Upload Cache" when `.dscode/uploads/` is empty or doesn't exist
+- **THEN** the server SHALL respond with `{ type: "upload_stats", files: 0, bytes: 0 }`
+- **AND** an info toast SHALL be shown: "No cached files to clear"
+
+#### Scenario: Upload stats sent on startup
+- **WHEN** the server starts or a client connects
+- **THEN** the server SHALL scan `.dscode/uploads/` and send the current stats via `{ type: "upload_stats", files: N, bytes: M }`

--- a/openspec/changes/archive/2026-07-15-fix-tui-file-drag-drop/tasks.md
+++ b/openspec/changes/archive/2026-07-15-fix-tui-file-drag-drop/tasks.md
@@ -1,0 +1,51 @@
+## 1. Bug: remove duplicate fileRefs split block in web-backend.ts
+
+- [ ] 1.1 In `src/ui/web/web-backend.ts`, remove the duplicate `fileRefs` split block at lines ~567-595 (identical to the correct block at lines ~538-566), which causes non-image paths to be injected twice into prompt text
+
+## 2. Config-driven file size limits (replace hardcoded 50KB)
+
+- [ ] 2.1 In `src/ui/shared/types.ts`, add `maxFileSize` and `maxTotalSize` to `ConfigData` type
+- [ ] 2.2 In web backend `buildConfigData()`, include `maxFileSize` / `maxTotalSize` from `atFile` config (defaults: 10MB / 50MB)
+- [ ] 2.3 In `App.tsx`, pass `config` prop to `MessageInput`
+- [ ] 2.4 In `MessageInput.tsx`, remove hardcoded `MAX_FILE_SIZE` and `MAX_TOTAL_SIZE` constants, read from `config` prop
+- [ ] 2.5 Size limits only apply to non-image, non-project-match files (external files via upload-to-temp)
+- [ ] 2.6 When a file is skipped due to size, show warning toast: "Skipped filename.ext (exceeds X MB limit)"
+- [ ] 2.7 When multiple files are skipped, show: "Skipped N files (exceeds size limit)"
+
+## 3. Project file matching: inject @path instead of reading content
+
+- [ ] 3.1 In `src/ui/shared/types.ts`, add `file_search` ClientCommand and `file_search_result` ServerEvent
+- [ ] 3.2 Server-side: in `web-backend.ts`, handle `file_search` command — search project files by exact filename, return paths
+- [ ] 3.3 In `App.tsx`, wire `file_search` command/event between MessageInput and WebSocket
+- [ ] 3.4 In `MessageInput.tsx` `handleDrop`, for non-image files, call `file_search` before reading content:
+  - 1 match → inject `@path` directly into input text (zero-transport)
+  - N matches → show file picker (reuse existing `showFileMenu`), user selects → inject `@path`
+  - 0 matches → fall through to existing upload-to-temp flow
+- [ ] 3.5 Ensure project-matched files skip both size check and content read
+
+## 4. Settings panel: upload cache management
+
+- [ ] 4.1 In `src/ui/shared/types.ts`, add `upload_stats` ServerEvent and `clear_uploads` ClientCommand
+- [ ] 4.2 Server: on `ready` event, scan `.dscode/uploads/` and send `{ type: "upload_stats", files: N, bytes: M }`
+- [ ] 4.3 Server: handle `clear_uploads` command — delete `.dscode/uploads/` recursively, return stats
+- [ ] 4.4 In `App.tsx`, handle `upload_stats` event — store in state, pass to Sidebar
+- [ ] 4.5 In `SettingsPanel` (Sidebar.tsx), add "Upload Cache" section with stats display and "Clear Upload Cache" button
+- [ ] 4.6 On clear success → toast: "Cleared N files (X MB)" and update stats to 0
+- [ ] 4.7 On clear when empty → toast: "No cached files to clear"
+
+## 5. TypeScript and manual test
+
+- [ ] 5.1 Run `npm run typecheck`
+- [ ] 5.2 Manual test (TUI): drag a `.ts` file, verify path ref without content
+- [ ] 5.3 Manual test (TUI): drag a `.png` file, verify ImagePipeline
+- [ ] 5.4 Manual test (TUI): drag both `.ts` and `.png`, verify mixed behavior
+- [ ] 5.5 Manual test (Web): drag a `.json` file, verify temp path + agent can read_file
+- [ ] 5.6 Manual test (Web): drag a `.png` file, verify ImagePipeline
+- [ ] 5.7 Manual test (Web): drag both `.json` and `.png`, verify mixed behavior
+- [ ] 5.8 Manual test (Web): verify temp files cleaned up after session end
+- [ ] 5.9 Manual test: drag project file `package.json` → injected as @package.json
+- [ ] 5.10 Manual test: drag file with ambiguous name → picker shown
+- [ ] 5.11 Manual test: drag external PDF <10MB → uploaded to temp
+- [ ] 5.12 Manual test: drag external file >10MB → toast warning + skip
+- [ ] 5.13 Manual test: Settings → Clear Upload Cache → toast + stats update
+- [ ] 5.14 Manual test: Settings → Clear when empty → "No cached files" toast

--- a/openspec/changes/archive/2026-07-15-fix-upload-binary-encoding/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-15-fix-upload-binary-encoding/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-plus
+created: 2026-07-15

--- a/openspec/changes/archive/2026-07-15-fix-upload-binary-encoding/consolidate.md
+++ b/openspec/changes/archive/2026-07-15-fix-upload-binary-encoding/consolidate.md
@@ -1,0 +1,68 @@
+## 变更综述
+
+文件拖拽上传的字节保真度演进：初始实现用 `readAsText()` 读取所有文件并用 UTF-8 写出，导致 PDF/DOCX 等二进制文件的非 UTF-8 字节被替换为 U+FFFD 而永久损坏。经过多次迭代（拖拽能力、格式协议、大小限制），最终通过 base64 编码管道实现 100% 字节精确还原。
+
+## 变更时间线
+
+- 2026-07-08: web-drag-drop-files — Web UI 支持拖拽文件插入 `@path`，FileAttachment 类型、文件芯片、双向同步
+- 2026-07-08: drag-drop-file-attachments — `[file:xxx]` 格式协议 + FileTracker，统一 Web/TUI 文件追踪
+- 2026-07-08: fix-at-image-size-limit — 修复 `@` 引用图片时的 50KB 限制
+- 2026-07-15: fix-file-upload-cache — 解除文件大小限制（50KB→10MB），新增上传缓存展示与清理
+- 2026-07-15: fix-upload-binary-encoding — 修复二进制文件上传编码损坏问题
+
+## 初始设计
+
+**问题**：Web UI 用户只能通过 `@` 自动补全或剪贴板粘贴引用文件，拖拽——最直观的方式——完全无效。
+
+**方案**：Web UI 输入区接受拖拽的 `File` 对象，用 `readAsText()` 读取内容，作为 `uploadedFile` 发送到后端，后端用 `writeFileSync(path, content, "utf-8")` 写入磁盘。
+
+## 变更记录
+
+### 变更: [file:xxx] 格式协议 + FileTracker
+
+- **触发**: 用户拖入文件后无法在编辑器中看到文件与提示词的关联
+- **改动**: 引入 `[file:displayPath]` 纯文本标记协议，FileTracker 统一 Web/TUI 文件追踪
+- **影响**: Web UI 的 `handleDrop` 改为注册 tracker + 芯片展示；TUI 新增拖拽处理和 attachment bar
+
+### 变更: 图片 @ 引用大小限制修复
+
+- **触发**: `resolveAtFileRefs` 对所有文件统一施加 50KB 限制，>50KB 图片被静默跳过
+- **改动**: 移除图片的 `maxFileSize` 门禁，新增 `maxImageSize`（20MB），图片不计入 `maxTotalSize`
+- **影响**: `at-file-resolver.ts`、`AtFileConfig` 类型、配置默认值
+
+### 变更: 解除文件大小限制 + 缓存管理
+
+- **触发**: 50KB/200KB 硬限制静默丢弃文件；上传缓存无限增长无感知
+- **改动**: 单文件上限 50KB→10MB，总计 200KB→50MB，超出 toast 提示；Settings 面板新增 Cache 区块；session 删除时清理上传目录
+- **影响**: `MessageInput.tsx`、`Sidebar.tsx`、`web-backend.ts`、shared types
+
+## 修复记录
+
+### 修复: 二进制文件上传编码损坏
+
+- **症状**: 拖入 PDF/DOCX 等二进制文件后，落盘文件字节与原始文件不一致——所有非 UTF-8 字节被替换为 U+FFFD 替换字符，文件永久损坏。`fix-file-upload-cache` 中标注为已知限制但未解决。
+- **根因**: 
+  - 前端 `MessageInput.tsx` 使用 `reader.readAsText(file)` 以 UTF-8 解码文件内容，非 UTF-8 字节被替换为 U+FFFD
+  - 后端 `web-backend.ts` 用 `writeFileSync(path, content, "utf-8")` 写出，再次编码转换
+  - 两次编解码导致原始字节永久丢失
+- **修复**: 
+  - 前端改用 `readAsArrayBuffer()` 读取原始字节 → 转 base64 字符串 → 通过 WebSocket 发送
+  - 后端改用 `Buffer.from(content, "base64")` 解码还原原始字节 → 直接写入磁盘
+  - 文本文件同样走 base64 管道（不再按 MIME type 分流），简化逻辑且保证字节精确
+  - 类型定义 `content: string` 保持不变（base64 编码后仍是 string）
+
+## 最终状态
+
+**问题**：Web UI 拖拽上传非图片文件时，前端用 `readAsText()` 以 UTF-8 解码，导致非 UTF-8 字节被永久替换为 U+FFFD；后端再以 UTF-8 写出，最终落盘文件已损坏不可用。
+
+**方案**：
+- 前端改用 base64 传输：`MessageInput` 对非图片文件统一用 `readAsArrayBuffer()` 读取，转 base64 后通过 WebSocket 发送
+- 后端改用 base64 解码写入：`web-backend.ts` 用 `Buffer.from(content, "base64")` 写出原始字节
+- 文本文件同样走 base64：不再按 MIME type 分流，统一 base64 简化逻辑且保证字节精确还原
+- 类型定义中 `content: string` 保持不变（base64 编码后仍是 string）
+
+**新增能力**：
+- `binary-upload-encoding`: 非图片文件拖拽上传时，前端以 base64 编码传输原始字节，后端解码还原写入磁盘
+
+**修改能力**：
+- `web-drag-drop-files`: "Non-image file within size limit" scenario 中 "read as text" 改为 "read as base64"

--- a/openspec/changes/archive/2026-07-15-fix-upload-binary-encoding/design.md
+++ b/openspec/changes/archive/2026-07-15-fix-upload-binary-encoding/design.md
@@ -1,0 +1,41 @@
+## Context
+
+当前 `fix-file-upload-cache` 变更已将非图片文件上传的 size limit 从 50KB 提升到 10MB。但前端 `MessageInput.handleDrop` 对非图片文件使用 `FileReader.readAsText(file)` 读取内容，以 UTF-8 解码后通过 WebSocket 发送；后端 `web-backend.ts` 以 `writeFileSync(path, content, "utf-8")` 写出。PDF、DOCX 等二进制文件经过「UTF-8 解码 → 字符串 → UTF-8 编码」往返后原始字节永久丢失，落盘文件损坏不可用。`fix-file-upload-cache` design.md 将此事标注为已知限制但不在 scope。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 非图片文件上传后落盘内容与原始文件 100% 字节一致
+- 图片文件路径不变（仍走 `readAsDataURL` + compress）
+- 文本文件同样走 base64，不做 MIME type 分流（避免维护两套路径）
+
+**Non-Goals:**
+- 不改变文件上传的存储路径（仍为 `.dscode/uploads/<sessionId>/`）
+- 不做上传进度条
+- 不做增量/流式上传
+- 不引入新的 WebSocket 消息类型（复用现有 `uploadedFiles[].content` 字段）
+
+## Decisions
+
+### 1. 统一用 base64 编码传输
+
+**方案**: 前端 `readAsArrayBuffer()` → `Buffer.from(arrayBuffer)` → `.toString("base64")`，后端 `Buffer.from(content, "base64")` → `writeFileSync(path, buffer)`。
+
+**替代方案考虑**:
+- **按 MIME type 分流**（text/* → readAsText, 其他 → base64）：需要维护两种读取和写入路径，逻辑分支增多，且 text/* 的范围模糊（如 `application/json`、`application/xml` 本质是文本但 MIME 不是 `text/*`），增加维护成本和潜在 bugs → 拒绝
+- **WebSocket binary frames**：需要改动 WebSocket 协议层，复杂度过高，且已有 JSON 文本帧的基建 → 拒绝
+- **HTTP multipart upload**：需引入额外路由和 HTTP 客户端逻辑，与纯 WebSocket 通信模式不一致 → 拒绝
+
+### 2. `content: string` 类型不变
+
+`uploadedFiles[].content` 在 `types.ts` 中已经是 `string`。base64 编码天然是 string，类型无需变更。唯一变化是语义：从「UTF-8 文本内容」变为「base64 编码的原始字节」。
+
+### 3. 后端 `writeFileSync` 去掉 encoding 参数
+
+原来 `writeFileSync(tempPath, uf.content, "utf-8")` 将字符串编码为 UTF-8 字节后写入。改为 `writeFileSync(tempPath, Buffer.from(uf.content, "base64"))`：先将 base64 字符串解码为原始 `Buffer`，再写入磁盘。`writeFileSync` 接收 `Buffer` 时不再做任何编码转换。
+
+## Risks / Trade-offs
+
+- [Risk] Base64 编码增加 33% 传输体积 — 对于 10MB 文件，WebSocket 消息约 13.3MB 的 JSON 字符串。Mitigation: 10MB 单文件限制已经控制了上限；对于 LAN/localhost WebSocket，延迟影响可忽略。
+- [Risk] 文本文件原本 `readAsText` 路径工作正常，改为 base64 后体积增加 — Mitigation: 10MB 限制下，对于几十 KB 的文本文件，base64 开销微不足道（33KB → 44KB）。统一路径消除分歧逻辑的价值远大于这点开销。
+- [Risk] 与已发送但未 consummate 的缓存文件不兼容 — Mitigation: 所有缓存文件是临时副本，用户本地有原始文件。且 fix-file-upload-cache 提供了 Clear Cache 功能。

--- a/openspec/changes/archive/2026-07-15-fix-upload-binary-encoding/proposal.md
+++ b/openspec/changes/archive/2026-07-15-fix-upload-binary-encoding/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+Web UI 拖拽上传非图片文件（PDF、DOCX 等二进制文件）时，前端用 `readAsText()` 以 UTF-8 解码文件内容，导致非 UTF-8 字节被替换为 U+FFFD 从而永久丢失原始数据；后端再以 UTF-8 写出，最终落盘文件已损坏不可用。`fix-file-upload-cache` 将其标注为已知限制但未解决，现在是时候修复了。
+
+## What Changes
+
+- **前端改用 base64 传输**：`MessageInput` 对非图片文件统一用 `readAsArrayBuffer()` 读取，转 base64 后通过 WebSocket 发送
+- **后端改用 base64 解码写入**：`web-backend.ts` 收到 `uploadedFiles[*].content` 后，用 `Buffer.from(content, "base64")` 写出原始字节
+- **文本文件同样走 base64**：不再按 MIME type 分流（text/* → readAsText, 其他 → base64），统一 base64 简化逻辑且保证字节精确还原
+- 类型定义中 `content: string` 保持不变（base64 编码后仍是 string）
+
+## Capabilities
+
+### New Capabilities
+- `binary-upload-encoding`: 非图片文件拖拽上传时，前端以 base64 编码传输原始字节，后端解码还原写入磁盘，确保 PDF/DOCX 等二进制文件 100% 字节精确
+
+### Modified Capabilities
+- `web-drag-drop-files`: "Non-image file within size limit" scenario 中 "read as text" 改为 "read as base64"
+
+## Impact
+
+- `web/src/components/MessageInput.tsx` — 第 485-490 行，`readAsText()` → `readAsArrayBuffer()` + base64 编码
+- `src/ui/web/web-backend.ts` — 第 528 行，`writeFileSync(path, content, "utf-8")` → `writeFileSync(path, Buffer.from(content, "base64"))`
+- `src/ui/shared/types.ts` — 无需改动（`content: string` 语义不变）
+- `openspec/specs/web-drag-drop-files/spec.md` — delta: 修改 "Non-image file within size limit" scenario

--- a/openspec/changes/archive/2026-07-15-fix-upload-binary-encoding/specs/binary-upload-encoding/spec.md
+++ b/openspec/changes/archive/2026-07-15-fix-upload-binary-encoding/specs/binary-upload-encoding/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: Non-image files uploaded as base64-encoded bytes
+Non-image files dropped onto the Web UI SHALL be read as raw bytes using `FileReader.readAsArrayBuffer()`, encoded as a base64 string, and transmitted to the server. The server SHALL decode the base64 string back to raw bytes and write them to disk without any text encoding conversion.
+
+#### Scenario: Binary file uploaded byte-accurately
+- **WHEN** the user drops a PDF file (or any non-image binary file) within size limits
+- **THEN** the file content SHALL be read via `readAsArrayBuffer()`
+- **AND** the ArrayBuffer SHALL be converted to a base64 string
+- **AND** the server SHALL decode the base64 string via `Buffer.from(content, "base64")`
+- **AND** the written file on disk SHALL be byte-identical to the original dropped file
+
+#### Scenario: Text file uploaded byte-accurately
+- **WHEN** the user drops a text file (`.txt`, `.md`, `.csv`, etc.) within size limits
+- **THEN** the file SHALL be read via `readAsArrayBuffer()` (not `readAsText()`)
+- **AND** encoded as base64 same as binary files
+- **AND** the written file on disk SHALL be byte-identical to the original dropped file
+
+#### Scenario: Image file path unchanged
+- **WHEN** the user drops an image file
+- **THEN** it SHALL continue to use the existing `readAsDataURL()` + compress pipeline
+- **AND** the base64 encoding path SHALL NOT apply to image files

--- a/openspec/changes/archive/2026-07-15-fix-upload-binary-encoding/specs/web-drag-drop-files/spec.md
+++ b/openspec/changes/archive/2026-07-15-fix-upload-binary-encoding/specs/web-drag-drop-files/spec.md
@@ -1,7 +1,5 @@
-## Purpose
+## MODIFIED Requirements
 
-Enable Web UI users to drag files and directories from their OS file manager directly onto the chat input area, with file metadata displayed as chips and paths inserted as @ references into the message text.
-## Requirements
 ### Requirement: Web UI prompt accepts drag-and-drop files
 The Web UI `MessageInput` component SHALL accept files and directories dragged from the OS file manager onto the textarea or its surrounding input area. Non-image files SHALL be read as raw bytes (via `readAsArrayBuffer()`), encoded as base64, and uploaded to the server if they are within size limits. Dropped files that exceed size limits SHALL produce a toast notification.
 
@@ -143,4 +141,3 @@ The help text in `commands.ts` SHALL accurately describe available image input m
 - **WHEN** the `/?` or `/help` command is issued
 - **THEN** the image/vision section SHALL NOT claim "In Web UI: drag & drop, paste, or click to upload images" if drag-and-drop or click-to-upload are not fully implemented
 - **AND** the text SHALL describe only currently supported methods: pasting images via Ctrl+V
-

--- a/openspec/changes/archive/2026-07-15-fix-upload-binary-encoding/tasks.md
+++ b/openspec/changes/archive/2026-07-15-fix-upload-binary-encoding/tasks.md
@@ -1,0 +1,19 @@
+## 1. Frontend — base64 encoding (MessageInput.tsx)
+
+- [x] 1.1 Replace `reader.readAsText(file)` with `reader.readAsDataURL(file)` + base64 extraction in `handleDrop`
+- [x] 1.2 After `reader.onload`, strip `data:<mime>;base64,` prefix to get raw base64: `dataUrl.substring(dataUrl.indexOf(',') + 1)`
+- [x] 1.3 The Promise type `Promise<string>` unchanged — base64 is still a string
+- [x] 1.4 Run `npm run typecheck` and verify MessageInput compiles
+
+## 2. Backend — base64 decoding (web-backend.ts)
+
+- [x] 2.1 Change `writeFileSync(tempPath, uf.content, "utf-8")` to `writeFileSync(tempPath, Buffer.from(uf.content, "base64"))` (line 528)
+- [x] 2.2 Run `npm run typecheck` and verify web-backend compiles
+
+## 3. Validation
+
+- [ ] 3.1 Manual test: drag a PDF (<10MB) into Web UI, verify the file in `.dscode/uploads/` is byte-identical to the original
+- [ ] 3.2 Manual test: drag a text file (.txt, .md), verify content is byte-identical
+- [ ] 3.3 Manual test: drag an image file, verify it still goes through the image compression pipeline (not the base64 path)
+- [ ] 3.4 Manual test: drag a binary file >10MB, verify toast appears and file not uploaded
+- [x] 3.5 Run `npm run build && npm test` and verify no regressions

--- a/openspec/changes/archive/2026-07-15-fix-webui-message-timestamp/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-15-fix-webui-message-timestamp/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-plus
+created: 2026-07-15

--- a/openspec/changes/archive/2026-07-15-fix-webui-message-timestamp/consolidate.md
+++ b/openspec/changes/archive/2026-07-15-fix-webui-message-timestamp/consolidate.md
@@ -1,0 +1,29 @@
+## 变更综述
+
+从建立共享 UI 数据模型消除 TUI/Web 类型漂移，到为消息模型添加时间戳字段并消除硬编码时间显示——本次变更补全了 `UIMessage` 的时间维度，使 Web UI 的聊天消息能显示真实的发送时间。
+
+## 变更时间线
+
+- 2026-05-29: `shared-ui-data-model` — 引入 `src/ui/shared/` 共享数据模型层，定义规范的 `UIMessage` 类型和 `conversationReducer`，消除 TUI/Web 的类型漂移
+- 2026-07-15: `fix-webui-message-timestamp` — 添加 `createdAt` 字段并替换硬编码时间字符串
+
+## 初始设计
+
+TUI 和 Web UI 各自维护独立的类型定义和状态构建逻辑，添加功能需要同时修改 6+ 文件，经常出现一端工作另一端损坏的情况。
+
+`shared-ui-data-model` 通过以下方式解决了这个问题：
+- 在 `src/ui/shared/` 中定义规范的 `UIMessage`、`ToolCallEntry`、`ContentBlock` 类型
+- 提供纯函数 `conversationReducer(state, event) → state` 供两端共用
+- Web UI 导入共享类型替代自己的拷贝
+- TUI `ConversationView` 采用相同的 `UIMessage` 模型
+
+## 最终状态
+
+Web UI 的聊天消息元信息行固定显示 `"09:41"`，无论消息实际何时发送。时间字符串硬编码在 `ChatView.tsx` 中，且 `UIMessage` 类型缺少 timestamp 字段。
+
+`fix-webui-message-timestamp` 做了以下修复：
+- 为 `UIMessage` 接口添加可选的 `createdAt?: number` 字段
+- 在 conversation reducer 创建用户消息和 assistant 消息时记录 `Date.now()` 作为 `createdAt`
+- 在 `ready` 事件映射中尝试从历史消息提取 timestamp（不可用时优雅降级）
+- 替换 `UserBubble` 和 `AssistantMessage` 中的硬编码 `"09:41"` 为 `toLocaleTimeString()` 格式化的真实值
+- `createdAt` 缺失时（如旧历史消息），从元信息行中省略时间而非显示错误值

--- a/openspec/changes/archive/2026-07-15-fix-webui-message-timestamp/design.md
+++ b/openspec/changes/archive/2026-07-15-fix-webui-message-timestamp/design.md
@@ -1,0 +1,93 @@
+## Context
+
+The Web UI (`ChatView.tsx`) displays a hardcoded `"09:41"` time string on every chat message meta line (`You · 09:41` / `dscode · 09:41`). The `UIMessage` type in `src/ui/shared/types.ts` has no timestamp field, so there is no data to drive a real timestamp. This makes message times misleading and useless.
+
+The current data flow:
+- `UIMessage` interface has `id`, `role`, `content`, `thinking`, `tools`, `isStreaming`, `images` — no timestamp
+- `conversationReducer` creates messages in `user_message`, `updateLastOrCreate`, and `ready` cases without recording creation time
+- `ChatView.tsx` `UserBubble` (line 369) and `AssistantMessage` (line 412) both hardcode `"09:41"`
+
+Constraints:
+- `UIMessage` is shared between TUI and Web UI; TUI does not display per-message timestamps and should not be affected
+- `conversationReducer` must remain pure (no `Date.now()` side effects in the reducer itself — but the reducer is called from harness code that can pass `createdAt` as part of the event)
+- No backend changes — timestamps are captured client-side
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add an optional `createdAt?: number` (epoch ms) field to `UIMessage`
+- Record `Date.now()` when messages are created (user messages, assistant messages)
+- Extract timestamps from historical messages when available (from backend `ready` event)
+- Display `createdAt` as a formatted time string (`toLocaleTimeString()`) in the Web UI meta line
+- Gracefully omit the time portion when `createdAt` is absent (legacy history)
+
+**Non-Goals:**
+- TUI timestamp display — TUI does not show per-message times
+- Backend changes — no modification to how the server stores or transmits timestamps
+- Timezone-aware formatting — use browser's default `toLocaleTimeString()` without custom locale logic
+- Relative timestamps ("2 minutes ago") — keep it simple with absolute time
+
+## Decisions
+
+### Decision 1: `createdAt` as optional `number` (epoch ms)
+
+**Choice:** Add `createdAt?: number` to `UIMessage` interface.
+
+**Rationale:** Optional means zero migration cost — existing code that doesn't read `createdAt` is unaffected. `number` stores epoch milliseconds, consistent with `Date.now()` and JavaScript conventions. Using epoch ms avoids serialization ambiguity and is directly compatible with `new Date(createdAt).toLocaleTimeString()`.
+
+**Alternatives considered:**
+- `createdAt?: Date` — rejected because `Date` objects don't serialize cleanly across the wire protocol; the reducer would need to reconstruct them
+- `createdAt: number` (required) — rejected because historical messages from `ready` may not have timestamps, and we don't want to fabricate values
+- `timestamp?: string` (ISO 8601) — rejected because it adds parsing overhead and is less ergonomic for `Date.now()` assignment
+
+### Decision 2: Timestamp assigned at the harness level, not inside the pure reducer
+
+**Choice:** The `conversationReducer` remains pure. Timestamps are injected into events before the reducer is called. Specifically:
+- `user_message` events carry an optional `createdAt` that the harness sets to `Date.now()` before dispatching
+- `updateLastOrCreate` accepts an optional `createdAt` parameter provided by the harness
+
+**Rationale:** The reducer is documented as pure and side-effect-free. Calling `Date.now()` inside it would violate that contract. The harness (which orchestrates event dispatch) is responsible for capturing wall-clock time.
+
+**Alternatives considered:**
+- `Date.now()` directly in the reducer — rejected because it breaks purity and makes testing harder
+- Using the `id` field (already contains `Date.now()`) as the timestamp source — rejected because `id` is an implementation detail, not a semantic timestamp, and historical messages have synthetic IDs like `hist-0`
+
+### Decision 3: Extract timestamp from `ready` event messages when available
+
+**Choice:** In the `ready` case, check if each historical `ConversationMessage` has a `createdAt` field (number) and propagate it to `UIMessage.createdAt`. If absent, leave `createdAt` undefined.
+
+**Rationale:** Some backends may include per-message timestamps. Using them when available makes history display accurate. When absent, the time portion is simply omitted — better than showing wrong times.
+
+### Decision 4: `toLocaleTimeString()` for display formatting
+
+**Choice:** Use `new Date(createdAt).toLocaleTimeString()` in `UserBubble` and `AssistantMessage`.
+
+**Rationale:** This produces a locale-appropriate short time format (e.g., "2:34 PM" in en-US, "14:34" in de-DE) without any custom formatting logic. The browser handles it natively.
+
+**Alternatives considered:**
+- Custom formatting with `getHours()/getMinutes()` — rejected as unnecessary complexity when `toLocaleTimeString()` already exists
+- `toLocaleString()` — rejected because it includes the date, which is too verbose for a message meta line
+
+### Decision 5: Omit time when `createdAt` is absent
+
+**Choice:** When `createdAt` is `undefined`, show only `"You"` / `"dscode"` without the time separator and time string.
+
+**Rationale:** Showing no time is honest. Showing a fabricated time (like the current `"09:41"`) is misleading. The meta line remains functional as a role label.
+
+## Risks / Trade-offs
+
+- **Risk:** Client-side `Date.now()` may drift from server time → **Mitigation:** The discrepancy is typically sub-second and invisible in a message display context. This is the standard approach for chat UIs.
+- **Risk:** `toLocaleTimeString()` output varies by browser locale, which may look inconsistent in screenshots → **Mitigation:** This is expected behavior; users see times in their own locale. If consistency is needed later, a `locales` option can be added.
+- **Risk:** Historical messages without `createdAt` show no time, creating visual inconsistency with new messages that have times → **Mitigation:** This is acceptable — the alternative (showing wrong times) is worse. Over time, all messages will have timestamps as old history scrolls out.
+
+## Migration Plan
+
+1. Add `createdAt?: number` to `UIMessage` — no breaking change
+2. Update reducer to propagate `createdAt` — existing behavior preserved when absent
+3. Update `UserBubble` and `AssistantMessage` to conditionally render time — backward compatible
+4. No data migration needed — `createdAt` is optional and populated at runtime
+5. Rollback: revert to hardcoded string — no data to clean up
+
+## Open Questions
+
+_(none)_

--- a/openspec/changes/archive/2026-07-15-fix-webui-message-timestamp/proposal.md
+++ b/openspec/changes/archive/2026-07-15-fix-webui-message-timestamp/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+The Web UI displays a hardcoded time string `"09:41"` on every chat message meta line (`You · 09:41` / `dscode · 09:41`). The time never changes regardless of when the message was actually sent, making it misleading and useless. The root cause is twofold: the `UIMessage` type has no timestamp field, and the `ChatView` component hardcodes the time string instead of formatting a real value.
+
+## What Changes
+
+- Add an optional `createdAt?: number` field to the `UIMessage` interface in `src/ui/shared/types.ts`
+- Record `Date.now()` as `createdAt` when the conversation reducer creates a new user message (`user_message` event) or a new assistant message (`updateLastOrCreate`)
+- Attempt to extract `createdAt` from historical messages in the `ready` event mapping (if the backend provides a timestamp); fall back gracefully if absent
+- Replace the hardcoded `"09:41"` string in `UserBubble` and `AssistantMessage` in `web/src/components/ChatView.tsx` with a `toLocaleTimeString()`-formatted value derived from `message.createdAt`
+- When `createdAt` is absent (e.g. legacy history messages without timestamps), omit the time portion from the meta line rather than showing a wrong value
+
+## Capabilities
+
+### New Capabilities
+
+_(none)_
+
+### Modified Capabilities
+
+- `shared-conversation-model`: Add `createdAt` field to `UIMessage` type and record it at creation time in the reducer
+- `web-frontend`: Display real per-message timestamps in the chat meta line instead of hardcoded string; gracefully omit time when timestamp is unavailable
+
+## Impact
+
+- **`src/ui/shared/types.ts`** — `UIMessage` interface gains `createdAt?: number`
+- **`src/ui/shared/reducer.ts`** — `user_message` case and `updateLastOrCreate` set `createdAt: Date.now()`; `ready` case attempts to read timestamp from historical message data
+- **`web/src/components/ChatView.tsx`** — `UserBubble` and `AssistantMessage` format `message.createdAt` via `toLocaleTimeString()` instead of hardcoded `"09:41"`
+- **No breaking changes** — `createdAt` is optional; existing code that doesn't read it is unaffected. The TUI does not display per-message timestamps and is not touched.
+- **No backend changes required** — timestamps are captured client-side at message creation. If the backend's `ready` event already includes per-message timestamps, they will be used; otherwise the field is simply absent for history.

--- a/openspec/changes/archive/2026-07-15-fix-webui-message-timestamp/prototype.md
+++ b/openspec/changes/archive/2026-07-15-fix-webui-message-timestamp/prototype.md
@@ -1,0 +1,5 @@
+## Prototype Status
+
+No prototype needed — minimal UI change. The only visual change is replacing a hardcoded `"09:41"` string with a dynamic `toLocaleTimeString()` value derived from `message.createdAt`. No new components, pages, layout shifts, or style changes. The meta line structure (`"You · HH:MM"` / `"dscode · HH:MM"`) remains identical; only the time value source changes from static to data-driven.
+
+When `createdAt` is absent (legacy history), the meta line condenses to just the role label (`"You"` / `"dscode"`) without the separator or time — a minor visual simplification within the existing design system.

--- a/openspec/changes/archive/2026-07-15-fix-webui-message-timestamp/specs/shared-conversation-model/spec.md
+++ b/openspec/changes/archive/2026-07-15-fix-webui-message-timestamp/specs/shared-conversation-model/spec.md
@@ -1,7 +1,5 @@
-## Purpose
+## MODIFIED Requirements
 
-Defines the canonical shared conversation data model — including UIMessage, ToolCallEntry, and ContentBlock types — and the pure conversationReducer function consumed by both TUI and Web UI to eliminate type drift and duplicate logic.
-## Requirements
 ### Requirement: Canonical UIMessage type
 The shared module SHALL define a canonical `UIMessage` type that represents a single conversation message with all possible content types (text, thinking, tool calls, images, streaming state) and an optional creation timestamp.
 
@@ -25,17 +23,6 @@ The shared module SHALL define a canonical `UIMessage` type that represents a si
 - **WHEN** a message is created by the reducer
 - **THEN** the `UIMessage` SHALL have an optional `createdAt?: number` field containing the epoch millisecond timestamp of message creation
 - **AND** when `createdAt` is absent, consumers SHALL treat the message as having no known creation time
-
-### Requirement: Canonical ToolCallEntry type
-The shared module SHALL define a canonical `ToolCallEntry` type representing a single tool invocation within an assistant message.
-
-#### Scenario: Tool call with result
-- **WHEN** a tool call completes
-- **THEN** the `ToolCallEntry` has `name: string`, `args: string`, `result: string`, `isError: boolean`, and optional `mcpApp?: McpAppInfo`
-
-#### Scenario: Tool call in progress
-- **WHEN** a tool call starts but hasn't completed
-- **THEN** the `ToolCallEntry` has `result: ""` indicating pending state
 
 ### Requirement: Conversation reducer function
 The shared module SHALL export a pure function `conversationReducer(prev: UIMessage[], event: ServerEvent): UIMessage[]` that transforms message state in response to server events.
@@ -91,15 +78,3 @@ The shared module SHALL export a pure function `conversationReducer(prev: UIMess
 #### Scenario: Ready event propagates timestamps
 - **WHEN** `ready` event is received with `messages` array where individual messages have an optional `createdAt` field
 - **THEN** the reducer SHALL set `UIMessage.createdAt` to the message's `createdAt` value if present, or leave it undefined otherwise
-
-### Requirement: Reducer is pure and side-effect-free
-The `conversationReducer` function SHALL be a pure function with no side effects, no external dependencies, and no DOM/Node API usage.
-
-#### Scenario: Same input produces same output
-- **WHEN** called with identical `prev` and `event` arguments
-- **THEN** the returned array is structurally identical
-
-#### Scenario: No mutation of input
-- **WHEN** called with a `prev` array
-- **THEN** the original `prev` array is not modified
-

--- a/openspec/changes/archive/2026-07-15-fix-webui-message-timestamp/specs/web-frontend/spec.md
+++ b/openspec/changes/archive/2026-07-15-fix-webui-message-timestamp/specs/web-frontend/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: Message timestamp display
+The frontend SHALL display the real creation time of each chat message in the meta line, formatted via the browser's locale-aware time formatting, and SHALL gracefully omit the time portion when a message has no timestamp.
+
+#### Scenario: User message shows real timestamp
+- **WHEN** a user message has `message.createdAt` set to a valid epoch millisecond value
+- **THEN** the `UserBubble` meta line SHALL display `"You · HH:MM AM/PM"` (locale-dependent) using `new Date(message.createdAt).toLocaleTimeString()`
+- **AND** the time string SHALL reflect the actual message creation time, not a hardcoded value
+
+#### Scenario: Assistant message shows real timestamp
+- **WHEN** an assistant message has `message.createdAt` set to a valid epoch millisecond value
+- **THEN** the `AssistantMessage` meta line SHALL display `"dscode · HH:MM AM/PM"` (locale-dependent) using `new Date(message.createdAt).toLocaleTimeString()`
+- **AND** the time string SHALL reflect the actual message creation time, not a hardcoded value
+
+#### Scenario: Message without timestamp omits time
+- **WHEN** a message has `message.createdAt` undefined or absent (e.g., legacy history messages)
+- **THEN** the meta line SHALL display only the role label (`"You"` for user, `"dscode"` for assistant) without the time separator or time string
+- **AND** no "09:41" or any hardcoded time string SHALL be displayed
+
+#### Scenario: Timestamp updates as new messages arrive
+- **WHEN** a new message is created during an active session
+- **THEN** its `createdAt` SHALL reflect the wall-clock time at creation
+- **AND** the displayed time SHALL differ from the time shown on previously created messages
+
+#### Scenario: All hardcoded time strings removed
+- **WHEN** the ChatView renders any message bubble (`UserBubble` or `AssistantMessage`)
+- **THEN** no hardcoded time string (such as `"09:41"`) SHALL appear anywhere in the meta line
+- **AND** all time values SHALL derive from `message.createdAt`

--- a/openspec/changes/archive/2026-07-15-fix-webui-message-timestamp/tasks.md
+++ b/openspec/changes/archive/2026-07-15-fix-webui-message-timestamp/tasks.md
@@ -1,0 +1,22 @@
+## 1. Data model — Add `createdAt` to UIMessage
+
+- [x] 1.1 Add `createdAt?: number` (epoch ms) to `UIMessage` interface in `src/ui/shared/types.ts`
+- [x] 1.2 Run `npm run typecheck` to verify no type errors from the new optional field
+
+## 2. Reducer — Record timestamps at message creation
+
+- [x] 2.1 In `user_message` case: add `createdAt: Date.now()` to the new user message object
+- [x] 2.2 In `updateLastOrCreate` function: add `createdAt: Date.now()` to newly created assistant messages (preserve existing `createdAt` on updated messages)
+- [x] 2.3 In `ready` case: propagate `m.createdAt` (if present as a number) from each historical conversation message to the mapped `UIMessage`
+- [x] 2.4 Run `npm run typecheck` to verify reducer changes compile
+
+## 3. Web UI — Display real timestamps
+
+- [x] 3.1 In `UserBubble` (`web/src/components/ChatView.tsx` line 369): replace hardcoded `"09:41"` with conditional rendering — show `new Date(message.createdAt).toLocaleTimeString()` when `createdAt` is defined, omit time when absent
+- [x] 3.2 In `AssistantMessage` (`web/src/components/ChatView.tsx` line 412): same replacement — replace hardcoded `"09:41"` with `message.createdAt ? new Date(message.createdAt).toLocaleTimeString() : null`
+- [x] 3.3 Run `npm run typecheck` to verify ChatView changes compile
+
+## 4. Validation
+
+- [x] 4.1 Run `npm run build` to confirm full build passes
+- [ ] 4.2 Manually verify in Web UI that new messages show current time and legacy history messages gracefully omit time

--- a/openspec/changes/archive/2026-07-15-toolcard-compact-spacing/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-15-toolcard-compact-spacing/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-plus
+created: 2026-07-15

--- a/openspec/changes/archive/2026-07-15-toolcard-compact-spacing/consolidate.md
+++ b/openspec/changes/archive/2026-07-15-toolcard-compact-spacing/consolidate.md
@@ -1,0 +1,37 @@
+## 变更综述
+
+从统一工具结果截断逻辑消除双管道不一致，到增强格式化实现代码高亮和 JSON pretty-print，再到修复 CSS 层叠层冲突导致的视觉间距问题——本次变更聚焦于 ToolCard 组件中内置工具结果的紧凑间距渲染，根因是 `@layer components` 中的样式被 Tailwind 的 `@layer utilities` 覆盖。
+
+## 变更时间线
+
+- 2025-07-14: `unify-tool-result-formatting` — 统一两条展示管道的工具结果截断逻辑到单一扼流点 `formatToolResultForUI`
+- 2025-07-14: `format-tool-results-in-ui` — 增加内容感知格式化（JSON、代码块），ToolCard 切换为 Markdown 渲染，定义 `tool-result-content-rendering` capability
+- 2026-07-15: `toolcard-compact-spacing` — 修复 CSS 层叠层冲突导致的内置工具结果间距过大问题
+
+## 初始设计
+
+工具结果在前端展示存在两条独立的管道（Live 路径和 History 路径），各自实现截断逻辑且不一致，导致"修一边漏一边"。
+
+`unify-tool-result-formatting` 创建了 `src/ui/shared/tool-result-formatter.ts` 作为单一扼流点，所有工具结果必经此函数，删除了两处各自的临时截断逻辑。
+
+## 变更记录
+
+### 变更: 工具结果智能格式化
+- **触发**: 工具结果在 ToolCard 中全部以纯文本渲染，JSON 压缩、Markdown 不解析、bash 无代码块包裹
+- **改动**: 增强 `formatToolResultForUI` 增加内容感知格式化；ToolCard 结果体切换为 Markdown 组件渲染；定义 `tool-result-content-rendering` capability
+- **影响**: ToolCard 内 `<pre>` 元素开始使用 Tailwind 的 `p-3` 和 `my-1` 工具类，为后续的 CSS 层叠层冲突埋下伏笔
+
+## 修复记录
+
+### 修复: 内置工具结果间距过大
+- **症状**: ToolCard 中内置工具（bash、read_file、grep、glob）结果在 header 和内容之间有 ~19px 的视觉间隙，而 MCP 工具仅 ~2px
+- **根因**: `index.css` 中 `.tool-card-body-inner pre { padding: 6px 10px; margin: 0 }` 位于 `@layer components`，但 Markdown 的 `<pre>` 使用 Tailwind `p-3` + `my-1`（位于 `@layer utilities`）。CSS 层叠层规范规定 `@layer utilities` 始终优先于 `@layer components`，无论特异性如何——所以组件层的覆盖从未生效
+- **修复**: 将 `.tool-card-body-inner pre` 样式移出 `@layer components` 到非层级 CSS（unlayered CSS 优先级高于所有 `@layer` 规则）；将 Markdown `<pre>` 的内联样式迁移为 CSS 类 `md-pre-base` 以允许覆盖；为 `.tool-card-body-inner` 添加 `background: var(--color-bg)`
+
+## 最终状态
+
+`toolcard-compact-spacing` 解决了 CSS 层叠层冲突导致的间距问题：
+- 将 `.tool-card-body-inner pre` 和 `.mcp-raw-block pre` 样式移出 `@layer components` 到非层级 CSS
+- 将 Markdown 组件 `<pre>` 的内联样式（`border`、`borderRadius`、`backgroundColor`、`color`）迁移为 CSS 类 `md-pre-base`
+- 为 `.tool-card-body-inner` 添加 `background: var(--color-bg)` 与 `.mcp-raw-block` 一致
+- `md-pre-base` 类在所有非 ToolCard 上下文中保持完全相同的视觉效果

--- a/openspec/changes/archive/2026-07-15-toolcard-compact-spacing/design.md
+++ b/openspec/changes/archive/2026-07-15-toolcard-compact-spacing/design.md
@@ -1,0 +1,55 @@
+## Context
+
+The ToolCard component renders tool call results in the web UI. The v3 changes (reduced padding, removed `border-top`, scoped `<pre>` CSS override) were applied but built-in tools still show a ~19px gap between header and content, while MCP tools show ~2px.
+
+**True root cause** (documented in `docs/prototypes/builtin-tool-result-rendering-fix-v5.html`):
+
+The scoped CSS rule `.tool-card-body-inner pre { padding: 6px 10px; margin: 0 }` lives inside `@layer components` in `index.css` (lines 102-547). The Markdown component's `<pre>` uses Tailwind classes `p-3` (12px) and `my-1` (4px), which live in `@layer utilities`. **CSS cascade layers dictate that `@layer utilities` always beats `@layer components`, regardless of specificity.** The override never worked — `<pre>` retains 12px padding + 4px margin.
+
+**Why built-in tools are affected but MCP tools are not:** `formatToolResultForUI` wraps built-in tool results (`bash`, `read_file`, `grep`, `glob`) in markdown code fences, rendering as `<pre>` with `p-3` + `my-1` = 16px gap. MCP tool results are typically plain text, rendering as `<p>` with 0 margin (Tailwind preflight) = 0px gap.
+
+Two additional issues compound the problem:
+1. The Markdown `<pre>` uses inline styles (`border`, `borderRadius`, `backgroundColor`) that CSS cannot override even with correct layering.
+2. `.tool-card-body-inner` lacks `background: var(--color-bg)` which `.mcp-raw-block` has.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make the scoped `<pre>` override actually work by moving it out of `@layer components` to unlayered CSS
+- Move Markdown `<pre>` inline styles to a CSS class so `border` and `border-radius` are also overridable
+- Add `background: var(--color-bg)` to `.tool-card-body-inner` for visual consistency with `.mcp-raw-block`
+- Reduce built-in tool ToolCard gap from ~19px to ~8px, matching MCP tool tightness
+
+**Non-Goals:**
+- Changing ToolCard header padding or layout
+- Changing the exec-card (in-progress MCP tool) spacing
+- Changing the progress bar container spacing
+- Changing `<pre>` styling in chat messages or other non-ToolCard contexts
+
+## Decisions
+
+### Decision 1: Move scoped `<pre>` override out of `@layer components` to unlayered CSS
+
+**Choice:** Remove the `.tool-card-body-inner pre` rule from the `@layer components` block. Place it in the unlayered section of `index.css` (after the `@layer components` closing brace).
+
+**Rationale:** Unlayered CSS beats all `@layer` rules regardless of specificity. This is the only way to override Tailwind utility classes (`p-3`, `my-1`) that live in `@layer utilities` without using `!important`. Moving just the ToolCard-scoped rule out of the layer has no effect on other components.
+
+**Alternative considered:** Use `!important` on the scoped CSS properties. Rejected — maintenance hazard, makes future changes harder to reason about. Also considered: putting the rule in `@layer utilities`. Rejected — while this would work, it mixes component-specific overrides with generic utilities, reducing clarity.
+
+### Decision 2: Move Markdown `<pre>` inline styles to CSS class `md-pre-base`
+
+**Choice:** In `web/src/components/Markdown.tsx`, replace `style={{ borderRadius, backgroundColor, border, color }}` on `<pre>` with `className="md-pre-base ..."`. Add `.md-pre-base` to unlayered CSS with identical values. Use `.tool-card-body-inner .md-pre-base` for scoped overrides.
+
+**Rationale:** Inline styles have specificity (1,0,0,0) which beats any CSS selector. Moving to a class makes `border`, `border-radius`, `background-color` overridable. The base class preserves identical appearance for all existing contexts.
+
+### Decision 3: Add `background: var(--color-bg)` to `.tool-card-body-inner`
+
+**Choice:** Add `background: var(--color-bg)` to `.tool-card-body-inner`, matching `.mcp-raw-block`.
+
+**Rationale:** Eliminates the color contrast between container padding (`--color-surface`) and `<pre>` background (`--color-bg`). This is a secondary fix — the primary gap reduction comes from Decision 1.
+
+## Risks / Trade-offs
+
+- **[Unlayered CSS overrides all layers]** → The unlayered `.tool-card-body-inner pre` rule will override any Tailwind utility on `<pre>` inside ToolCard. This is intentional and scoped — only affects `<pre>` elements inside `.tool-card-body-inner`. Mitigation: the selector is specific enough to not affect other contexts.
+- **[Markdown `<pre>` class change affects all contexts]** → The base class `md-pre-base` must produce identical appearance to current inline styles. Mitigation: copy exact values into the class. Add visual regression check for chat message code blocks.
+- **[CSS class name collision]** → `md-pre-base` is a custom class, unlikely to collide with Tailwind utilities. Mitigation: use a distinctive prefix.

--- a/openspec/changes/archive/2026-07-15-toolcard-compact-spacing/proposal.md
+++ b/openspec/changes/archive/2026-07-15-toolcard-compact-spacing/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+The ToolCard component has a visually excessive gap (~19px) between the header and the result content for built-in tools. MCP tools do not have this problem (~2px gap). 
+
+**True root cause:** The scoped CSS rule `.tool-card-body-inner pre { padding: 6px 10px; margin: 0 }` is inside `@layer components` in `index.css`. But the Markdown component's `<pre>` uses Tailwind classes `p-3` (12px padding) and `my-1` (4px margin), which live in `@layer utilities`. CSS cascade layers dictate that `@layer utilities` always beats `@layer components` regardless of specificity — so the override never worked. The `<pre>` retains 12px padding + 4px margin.
+
+**Why built-in tools are affected but MCP tools are not:** Built-in tool results (`bash`, `read_file`, `grep`, `glob`) are wrapped in markdown code fences by `formatToolResultForUI`, rendering as `<pre>` elements with `p-3` + `my-1` = 16px of padding/margin. MCP tool results are typically plain text, rendering as `<p>` elements with 0 margin (Tailwind preflight reset) = 0px gap.
+
+Additionally, the Markdown `<pre>` uses inline styles for `border`, `borderRadius`, and `backgroundColor`, which CSS selectors cannot override even with correct layering. And `.tool-card-body-inner` lacks `background: var(--color-bg)` which `.mcp-raw-block` has.
+
+The v5 prototype (`builtin-tool-result-rendering-fix-v5.html`) documents the true root cause and fix.
+
+## What Changes
+
+- Move `.tool-card-body-inner pre` (and `.mcp-raw-block pre`) CSS rules **out of `@layer components`** to unlayered CSS — unlayered CSS beats all `@layer` rules, so `padding: 6px 10px` and `margin: 0` will actually override Tailwind's `p-3` and `my-1`
+- Move Markdown component `<pre>` inline styles (`border`, `borderRadius`, `backgroundColor`, `color`) to a CSS class `md-pre-base` — makes `border: none` and `border-radius: 4px` overridable via scoped CSS
+- Add `background: var(--color-bg)` to `.tool-card-body-inner` — matches `.mcp-raw-block`, eliminates color contrast gap
+- The base `md-pre-base` class preserves identical appearance for all non-ToolCard contexts (chat messages, artifacts, etc.)
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `tool-result-content-rendering`: The ToolCard visual spacing requirements change — `.tool-card-body-inner` SHALL have `background: var(--color-bg)` and scoped `<pre>` overrides SHALL be in unlayered CSS (not `@layer components`) so they can override Tailwind utilities. The Markdown `<pre>` SHALL use CSS classes (not inline styles) for `border`, `border-radius`, `background-color`, and `color`.
+
+## Impact
+
+- **CSS**: `web/src/index.css` — move `.tool-card-body-inner pre` out of `@layer components` to unlayered section; add `background: var(--color-bg)` to `.tool-card-body-inner`; add `.md-pre-base` class
+- **Component**: `web/src/components/Markdown.tsx` — replace `<pre>` inline `style={{}}` with `className="md-pre-base ..."`
+- **Prototype**: `docs/prototypes/builtin-tool-result-rendering-fix-v5.html` — true root cause analysis and fix visualization
+- **No breaking changes** — `md-pre-base` class produces identical appearance to previous inline styles for all existing contexts; unlayered CSS only affects ToolCard-scoped selectors

--- a/openspec/changes/archive/2026-07-15-toolcard-compact-spacing/prototype.md
+++ b/openspec/changes/archive/2026-07-15-toolcard-compact-spacing/prototype.md
@@ -1,0 +1,9 @@
+## Prototype Files
+
+- `docs/prototypes/builtin-tool-result-rendering-fix-v3.html` — 4-variant spacing comparison. **Confirmed: Variant D (Ultra-compact, no border-top)** — selected as the design direction.
+- `docs/prototypes/builtin-tool-result-rendering-fix-v4.html` — Intermediate analysis (background + inline styles). Superseded by v5.
+- `docs/prototypes/builtin-tool-result-rendering-fix-v5.html` — **True root cause: CSS cascade layers.** Shows that `.tool-card-body-inner pre` is in `@layer components` while Tailwind's `.p-3` and `.my-1` are in `@layer utilities`. Utilities always beats components regardless of specificity — the scoped override never worked. `<pre>` retains 12px padding + 4px margin. Also explains why built-in tools (code fence → `<pre>` with p-3+my-1 = 16px gap) are affected but MCP tools (plain text → `<p>` with 0 margin = 0px gap) are not. Fix: move override to unlayered CSS + move `<pre>` inline styles to CSS class.
+
+## Prototype Status
+
+Prototype confirmed. v3 selected Variant D (ultra-compact). v5 identified the true root cause: CSS cascade layers prevent `@layer components` rules from overriding `@layer utilities` (Tailwind classes). The v3 scoped override never worked. Fix: (1) move `.tool-card-body-inner pre` to unlayered CSS, (2) move Markdown `<pre>` inline styles to `md-pre-base` class, (3) add `background: var(--color-bg)` to `.tool-card-body-inner`.

--- a/openspec/changes/archive/2026-07-15-toolcard-compact-spacing/specs/tool-result-content-rendering/spec.md
+++ b/openspec/changes/archive/2026-07-15-toolcard-compact-spacing/specs/tool-result-content-rendering/spec.md
@@ -1,0 +1,58 @@
+## MODIFIED Requirements
+
+### Requirement: ToolCard single Markdown block rendering
+The ToolCard component SHALL render the entire formatted tool result as a single `<Markdown>` block rather than splitting by newlines into individual per-line `<Markdown>` components. This ensures that multi-line markdown constructs (code fences, tables, lists) are correctly parsed as complete structures. The `.tool-card-body-inner` container SHALL use ultra-compact spacing: `padding: 2px 14px 6px`, `margin-top: 0`, `background: var(--color-bg)`, and SHALL NOT have a `border-top`. The `background: var(--color-bg)` on the container ensures the padding gap is visually invisible, matching `.mcp-raw-block` behavior. The Markdown component's `<pre>` element SHALL use CSS classes (not inline styles) for `border`, `border-radius`, `background-color`, and `color` so that scoped CSS overrides within ToolCard context are effective.
+
+#### Scenario: JSON code block renders as single element
+- **WHEN** a formatted tool result contains a markdown code fence (e.g., ```` ```json ... ``` ````)
+- **THEN** ToolCard SHALL pass the entire result string to a single `<Markdown>` component
+- **AND** SHALL NOT split the string on newlines into separate `<Markdown>` components
+- **AND** the rendered output SHALL appear as one contiguous code block, not multiple fragmented blocks
+
+#### Scenario: Plain text result rendered correctly
+- **WHEN** a formatted tool result is plain text (no markdown constructs)
+- **THEN** ToolCard SHALL still render it as a single `<Markdown>` block
+- **AND** line breaks within the plain text SHALL be preserved by the Markdown renderer
+
+#### Scenario: Compact spacing between header and content
+- **WHEN** a ToolCard is expanded and renders result content
+- **THEN** the `.tool-card-body-inner` container SHALL have `padding: 2px 14px 6px` and `margin-top: 0`
+- **AND** the container SHALL NOT have a `border-top` property
+- **AND** the total vertical gap from the header bottom edge to the first content character SHALL be approximately 8px (2px container padding + 6px `<pre>` padding), with no visible color contrast gap between container and `<pre>`
+
+#### Scenario: Scoped pre element styling
+- **WHEN** a `<pre>` element renders inside `.tool-card-body-inner` or `.mcp-raw-block`
+- **THEN** the `<pre>` SHALL have `padding: 6px 10px`, `margin: 0`, `border: none`, and `border-radius: 4px` via scoped CSS class override (the Markdown component SHALL NOT use inline styles for these properties)
+- **AND** `<pre>` elements outside ToolCard context (e.g., in chat messages) SHALL NOT be affected — they SHALL retain `border: 1px solid`, `border-radius: 8px`, and `background: var(--color-bg)` via the base `md-pre-base` CSS class
+
+### Requirement: MCP tool result raw block rendering
+When an MCP tool result is not valid JSON, the ToolCard SHALL render the result as a `.mcp-raw-block` with monospace font, pre-wrap whitespace, and 280px max-height with internal scroll. The `.mcp-raw-block` SHALL use ultra-compact spacing: `padding: 2px 14px 6px` and SHALL NOT have a `border-top`.
+
+#### Scenario: MCP plain text renders as raw block
+- **WHEN** an MCP tool result is plain text or code (not JSON)
+- **THEN** ToolCard SHALL render `<div class="mcp-raw-block">` containing the full result text
+- **AND** the block SHALL have `font-family: JetBrains Mono`, `white-space: pre-wrap`, `max-height: 280px; overflow-y: auto`
+- **AND** the block SHALL have `padding: 2px 14px 6px` with no `border-top`
+
+#### Scenario: Raw block preserves line breaks
+- **WHEN** an MCP tool returns multi-line output
+- **THEN** the raw block SHALL preserve all newlines and whitespace
+- **AND** the block SHALL scroll internally when content exceeds 280px
+
+### Requirement: MCP tool result rich list rendering
+When a tool with `mcp__` prefix returns a result that is valid JSON (starts with `{` or `[`), the ToolCard SHALL render the result as a `.mcp-rich-list` component instead of a standard code-fenced block. The rich list SHALL display structured results as vertically stacked cards with title, score, URL, content, and metadata. The `.mcp-rich-list` SHALL NOT have a `border-top` — visual separation relies on background contrast.
+
+#### Scenario: MCP JSON array renders as rich list
+- **WHEN** an MCP tool result is a JSON array
+- **THEN** ToolCard SHALL render `<div class="mcp-rich-list">` with one `<div class="mcp-rich-item">` per array element
+- **AND** each item SHALL attempt to extract `title`, `score`, `url`, `content` fields from the JSON object
+- **AND** unrecognized fields SHALL be ignored
+
+#### Scenario: MCP JSON object renders as rich list
+- **WHEN** an MCP tool result is a JSON object containing a search results-like structure
+- **THEN** ToolCard SHALL attempt to render it as a rich list using the same field extraction logic
+
+#### Scenario: Rich list compact spacing
+- **WHEN** a `.mcp-rich-list` renders inside a ToolCard
+- **THEN** the list SHALL NOT have a `border-top` property
+- **AND** visual separation from the header SHALL rely on background contrast

--- a/openspec/changes/archive/2026-07-15-toolcard-compact-spacing/tasks.md
+++ b/openspec/changes/archive/2026-07-15-toolcard-compact-spacing/tasks.md
@@ -1,0 +1,30 @@
+## 1. CSS — `.tool-card-body-inner` compact spacing (v3, done)
+
+- [x] 1.1 In `web/src/index.css`, modify `.tool-card-body-inner`: remove `border-top`, remove `margin-top: 2px`, change padding to `padding: 2px 14px 6px`
+- [x] 1.2 Add scoped `.tool-card-body-inner pre` rule inside `@layer components` (note: this NEVER worked due to cascade layers — fixed in task 4)
+- [x] 1.3 Add CSS comment about specificity (note: incorrect — the real issue is cascade layers, not specificity)
+
+## 2. CSS — `.mcp-raw-block` compact spacing (v3, done)
+
+- [x] 2.1 In `web/src/index.css`, modify `.mcp-raw-block`: remove `border-top`, change padding to `padding: 2px 14px 6px`
+
+## 3. CSS — `.mcp-rich-list` consistency (v3, done)
+
+- [x] 3.1 In `web/src/index.css`, modify `.mcp-rich-list`: remove `border-top` for consistency
+
+## 4. Root cause fix — cascade layers + inline styles + background (v5)
+
+- [x] 4.1 In `web/src/index.css`, **move** the `.tool-card-body-inner pre` rule **out of `@layer components`** to the unlayered section (after the closing `}` of `@layer components`). This is the critical fix — unlayered CSS beats `@layer utilities`, so `padding: 6px 10px` and `margin: 0` will finally override Tailwind's `p-3` (12px) and `my-1` (4px). Update the CSS comment to explain cascade layers, not specificity.
+- [x] 4.2 In `web/src/components/Markdown.tsx`, replace `<pre>` inline `style={{ borderRadius, backgroundColor, border, color }}` with `className="md-pre-base ..."` — inline styles prevent CSS from overriding `border` and `border-radius`
+- [x] 4.3 In `web/src/index.css` (unlayered section), add `.md-pre-base` class with exact same values as previous inline styles: `border-radius: 8px; background-color: var(--color-bg); border: 1px solid var(--color-border); color: var(--color-text)` — ensures zero visual regression for chat messages and other contexts
+- [x] 4.4 In `web/src/index.css` (unlayered section), update scoped override to `.tool-card-body-inner .md-pre-base` with `padding: 6px 10px; margin: 0; border: none; border-radius: 4px` — now ALL properties take effect (unlayered + class-based, no inline style conflict)
+- [x] 4.5 In `web/src/index.css`, add `background: var(--color-bg)` to `.tool-card-body-inner` — eliminates color contrast gap, matching `.mcp-raw-block`
+
+## 5. Verification
+
+- [x] 5.1 Run `npm run typecheck` to ensure no compilation errors
+- [x] 5.2 Run `npm run build` to verify the web frontend builds successfully
+- [ ] 5.3 Visual check: trigger a built-in tool (e.g., `bash`, `list_files`), expand the ToolCard — confirm `<pre>` has 6px padding (not 12px), 0 margin (not 4px), no border, and total header→content gap is ~8px
+- [ ] 5.4 Visual check: built-in tool ToolCard should now visually match MCP tool ToolCard tightness
+- [ ] 5.5 Visual check: confirm chat message `<pre>` blocks (outside ToolCard) are unaffected — still have `1px solid` border, `8px` border-radius, `12px` padding, and `--color-bg` background (via `.md-pre-base` base class + Tailwind `p-3`)
+- [ ] 5.6 Visual check: trigger an MCP tool with non-JSON result, confirm `.mcp-raw-block` still looks correct

--- a/openspec/changes/subagent-design-proposal/prototype.md
+++ b/openspec/changes/subagent-design-proposal/prototype.md
@@ -1,0 +1,3 @@
+## Prototype Status
+
+No prototype needed — this is a design proposal for subagent architecture. It involves backend system design and does not introduce or modify any UI components, pages, or visual interaction patterns.

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -6,13 +6,19 @@ context: |
   It extends spec-driven with two additional artifacts:
 
   1. **prototype** (optional, Explore-triggered):
-     When Explore discussions involve frontend/UI topics (页面, 界面, 组件,
-     交互, CSS, dashboard, landing, redesign, 动效等), naturally offer to
+     When Explore discussions involve frontend/UI topics (UI, page, component,
+     interaction, CSS, dashboard, landing, redesign, animation, etc.), naturally offer to
      create an HTML prototype. See explore command for the full workflow
      (load `html-output` skill → extract CSS variables → generate HTML at
      `docs/prototypes/<name>.html`). Load `prototype-workflow` skill for constraints. Prototype does NOT block apply.
 
-  2. **consolidate** (pre-archive, auto-triggered):
+  2. **explore options → prototypes** (behavioral rule for explore mode):
+    When exploring a problem and multiple approaches emerge, do NOT ask the user
+    "which one?" — instead, create visual comparisons (ASCII diagrams for
+    architecture/logic, HTML prototypes for UI/frontend) showing each option
+    side-by-side. The user compares with their eyes, not their imagination.
+
+  3. **consolidate** (pre-archive, auto-triggered):
      Before archiving, merge the current proposal with related archived change
      proposals into a unified narrative (consolidate.md). Scans archive/ for
      related changes by topic/keywords. Always generated — even if no related

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -5,12 +5,13 @@ context: |
   This project uses a custom OpenSpec schema: **spec-driven-plus**.
   It extends spec-driven with two additional artifacts:
 
-  1. **prototype** (optional, Explore-triggered):
-     When Explore discussions involve frontend/UI topics (UI, page, component,
-     interaction, CSS, dashboard, landing, redesign, animation, etc.), naturally offer to
-     create an HTML prototype. See explore command for the full workflow
+  1. **prototype** (mandatory, blocks tasks creation):
+     For UI changes, reference HTML prototype files from `docs/prototypes/`
+     that were created during explore. For non-UI changes, write a stub stating
+     no prototype is needed. The prototype artifact is mandatory — tasks cannot
+     be created until prototype exists. See explore command for the full workflow
      (load `html-output` skill → extract CSS variables → generate HTML at
-     `docs/prototypes/<name>.html`). Load `prototype-workflow` skill for constraints. Prototype does NOT block apply.
+     `docs/prototypes/<name>.html`). Load `prototype-workflow` skill for constraints.
 
   2. **explore options → prototypes** (behavioral rule for explore mode):
     When exploring a problem and multiple approaches emerge, do NOT ask the user

--- a/openspec/schemas/spec-driven-plus/schema.yaml
+++ b/openspec/schemas/spec-driven-plus/schema.yaml
@@ -129,31 +129,32 @@ artifacts:
   - id: prototype
     generates: prototype.md
     description: >-
-      Frontend prototype design (optional, Explore-triggered, does not block apply)
+      Prototype manifest — mandatory artifact that blocks tasks creation. For UI
+      changes, references HTML prototypes from docs/prototypes/. For non-UI
+      changes, contains a stub stating no prototype is needed.
     template: prototype.md
     instruction: |
-      Create a prototype design artifact when Explore discussion involves frontend/UI needs.
+      Create the prototype manifest artifact. This is **mandatory** for all
+      changes — it blocks task creation until complete.
 
-      This artifact is **optional** — only create in these scenarios:
-      - New UI components or pages
-      - Visual style changes
-      - Interaction flow redesign
-      - User explicitly requests a prototype
+      For UI changes (new components, pages, visual interaction, style changes):
+      - Reference HTML prototype files from `docs/prototypes/` that were created
+        during explore (e.g., `docs/prototypes/<change-name>-*.html`)
+      - List each prototype file path with a summary of the visual direction and
+        key design decisions confirmed during visual iteration
+      - If no HTML prototype was created during explore but the change involves
+        UI, provide a brief visual direction description based on design.md
 
-      Content sections:
-      - **Visual Direction**: Color palette, typography, spacing philosophy, mood
-      - **Layout**: ASCII wireframe or Mermaid structural diagram showing component hierarchy
-      - **Interaction Flow**: Key state transitions using state diagrams or numbered steps
-      - **Design References**: Inspiration sources, existing components, constraints
-      - **Accessibility Notes**: Keyboard, screen reader, contrast, motion considerations
+      For non-UI changes (backend-only, config, refactoring):
+      - Write a stub: "No prototype needed — <one-line reason>"
+      - Example: "No prototype needed — backend-only change affecting the
+        config loader module."
 
-      If the Explore conversation already produced enough design thinking,
-      extract and organize it directly. If more info is needed, ask 1-2 key
-      questions before creating.
-
-      This produces a single prototype.md. Do NOT write HTML/CSS code —
-      that happens during the apply phase.
-    requires: []
+      The prototype artifact is the bridge between explore's visual exploration
+      and the implementation tasks. HTML prototypes are created during explore
+      (not here) — this artifact references and summarizes them.
+    requires:
+      - design
 
   - id: tasks
     generates: tasks.md
@@ -176,6 +177,7 @@ artifacts:
     requires:
       - specs
       - design
+      - prototype
 
   - id: consolidate
     generates: consolidate.md

--- a/openspec/schemas/spec-driven-plus/templates/prototype.md
+++ b/openspec/schemas/spec-driven-plus/templates/prototype.md
@@ -1,38 +1,18 @@
-## Visual Direction
+## Prototype Files
 
-<!-- Color palette, typography, spacing philosophy, mood -->
-<!-- Example: Dark theme, Inter + JetBrains Mono, 8pt grid, editorial tone -->
+<!-- For UI changes: list HTML prototype files from docs/prototypes/ -->
+<!-- For non-UI changes: delete this section and use "Prototype Status" below -->
 
-## Layout
+<!-- Example:
+- `docs/prototypes/<change-name>-main-view.html` — Dark theme, 3-column layout,
+  collapsible sidebar. Confirmed: toast notifications top-right, 12px rounded cards.
+- `docs/prototypes/<change-name>-mobile-view.html` — Stacked layout, bottom nav bar.
+  Confirmed: swipe gestures for tab switching.
+-->
 
-<!-- Wireframe or structural diagram (ASCII art or Mermaid) -->
-<!-- Show component hierarchy, not pixel-level details -->
+## Prototype Status
 
-```
-┌─────────────────────────────────────┐
-│                                     │
-│              (sketch)               │
-│                                     │
-└─────────────────────────────────────┘
-```
+<!-- For non-UI changes: state that no prototype is needed with a one-line reason -->
+<!-- Example: No prototype needed — backend-only change affecting the config loader module. -->
 
-## Interaction Flow
-
-<!-- Key state transitions or user journey -->
-<!-- Use state diagrams or numbered steps -->
-
-```mermaid
-stateDiagram-v2
-    [*] --> Idle
-    Idle --> Active: trigger
-    Active --> Done: complete
-```
-
-## Design References
-
-<!-- Inspiration, existing patterns, constraints -->
-<!-- Links to existing components or external references -->
-
-## Accessibility Notes
-
-<!-- Keyboard, screen reader, contrast, motion considerations -->
+No prototype needed — <one-line reason: e.g., backend-only change, config update, refactoring with no UI impact>.

--- a/openspec/specs/binary-upload-encoding/spec.md
+++ b/openspec/specs/binary-upload-encoding/spec.md
@@ -1,0 +1,26 @@
+# binary-upload-encoding Specification
+
+## Purpose
+TBD - created by archiving change fix-upload-binary-encoding. Update Purpose after archive.
+## Requirements
+### Requirement: Non-image files uploaded as base64-encoded bytes
+Non-image files dropped onto the Web UI SHALL be read as raw bytes using `FileReader.readAsArrayBuffer()`, encoded as a base64 string, and transmitted to the server. The server SHALL decode the base64 string back to raw bytes and write them to disk without any text encoding conversion.
+
+#### Scenario: Binary file uploaded byte-accurately
+- **WHEN** the user drops a PDF file (or any non-image binary file) within size limits
+- **THEN** the file content SHALL be read via `readAsArrayBuffer()`
+- **AND** the ArrayBuffer SHALL be converted to a base64 string
+- **AND** the server SHALL decode the base64 string via `Buffer.from(content, "base64")`
+- **AND** the written file on disk SHALL be byte-identical to the original dropped file
+
+#### Scenario: Text file uploaded byte-accurately
+- **WHEN** the user drops a text file (`.txt`, `.md`, `.csv`, etc.) within size limits
+- **THEN** the file SHALL be read via `readAsArrayBuffer()` (not `readAsText()`)
+- **AND** encoded as base64 same as binary files
+- **AND** the written file on disk SHALL be byte-identical to the original dropped file
+
+#### Scenario: Image file path unchanged
+- **WHEN** the user drops an image file
+- **THEN** it SHALL continue to use the existing `readAsDataURL()` + compress pipeline
+- **AND** the base64 encoding path SHALL NOT apply to image files
+

--- a/openspec/specs/explore-prototype-workflow/spec.md
+++ b/openspec/specs/explore-prototype-workflow/spec.md
@@ -1,5 +1,7 @@
-## Requirements
+## Purpose
 
+Defines the HTML-first prototype workflow triggered from explore mode — including output directory conventions, naming rules, constraint file, and skill loading sequence — ensuring visual exploration produces consistent, style-aligned, and retainable HTML artifacts.
+## Requirements
 ### Requirement: HTML prototype output directory
 HTML prototypes generated during explore mode SHALL be placed in `docs/prototypes/` with the naming convention `<change-name>-<descriptor>.html`.
 
@@ -23,7 +25,7 @@ HTML prototypes generated during explore mode SHALL be placed in `docs/prototype
 - **THEN** it reads `docs/prototypes/prototype.md` first to obtain constraints
 
 ### Requirement: Explore command prototype section
-The explore command file (`.claude/commands/opsx/explore.md` and `.clinerules/workflows/opsx-explore.md`) SHALL contain a "Create HTML prototypes for frontend ideas" section under "What You Might Do".
+The explore command file (`.dscode/commands/opsx/explore.md`, `.clinerules/workflows/opsx-explore.md`, and `.claude/commands/opsx/explore.md`) SHALL contain a "Create HTML prototypes for frontend ideas" section under "What You Might Do" AND an "Ending Discovery" section that unconditionally directs to `/opsx:propose`.
 
 #### Scenario: Detection keywords
 - **WHEN** an explore discussion mentions UI, 页面, 界面, 组件, 交互, 样式, 视觉, CSS, frontend, landing, dashboard, 原型, prototype, redesign, or 动效
@@ -36,6 +38,10 @@ The explore command file (`.claude/commands/opsx/explore.md` and `.clinerules/wo
 #### Scenario: Visual iteration
 - **WHEN** a prototype is generated
 - **THEN** the agent SHALL accept visual feedback and iterate on the HTML prototype before capturing final design decisions
+
+#### Scenario: Ending discovery unconditionally goes to propose
+- **WHEN** explore ends, regardless of whether a prototype was created
+- **THEN** the agent SHALL direct the user to `/opsx:propose` as the next step and SHALL NOT suggest `/opsx:apply`
 
 ### Requirement: System Prompt prototype alignment
 The System Prompt (AGENTS.md) SHALL describe the HTML prototype workflow consistently with the explore command.
@@ -56,8 +62,71 @@ The existing `mcp-toolcard-execution-view-prototype.html` at the project root SH
 - **THEN** `docs/prototypes/mcp-toolcard-execution-view-prototype.html` exists and the project root copy is removed
 
 ### Requirement: OpenSpec config alignment
-`openspec/config.yaml` SHALL describe the prototype artifact in terms consistent with the HTML-first workflow.
+`openspec/config.yaml` SHALL describe the prototype artifact as mandatory and blocking tasks, consistent with the schema-level gate.
 
-#### Scenario: Config description updated
+#### Scenario: Config description reflects mandatory prototype
 - **WHEN** `openspec/config.yaml` is read
-- **THEN** the prototype artifact description references HTML prototypes, `docs/prototypes/`, and the `html-output` skill — not `prototype.md` as output and not `openspec instructions prototype` as the generation method
+- **THEN** the prototype artifact description SHALL state it is mandatory and blocks `tasks` creation — NOT "optional" or "does not block apply"
+
+#### Scenario: Config references HTML prototypes
+- **WHEN** `openspec/config.yaml` describes the prototype workflow
+- **THEN** it SHALL reference HTML prototypes, `docs/prototypes/`, and the `html-output` skill — not `prototype.md` as output and not `openspec instructions prototype` as the generation method
+
+### Requirement: Schema-level prototype gate
+The `spec-driven-plus` schema SHALL enforce `prototype` as a dependency of `tasks`. The `tasks` artifact's `requires` list SHALL include `prototype`, so the CLI blocks task creation until the prototype artifact exists.
+
+#### Scenario: Tasks blocked without prototype
+- **WHEN** a change's `prototype` artifact has not been created
+- **THEN** `openspec status` SHALL show `tasks` as `blocked` and `openspec instructions tasks` SHALL refuse to proceed
+
+#### Scenario: Tasks unblocked after prototype
+- **WHEN** a change's `prototype` artifact has been created (either UI manifest or non-UI stub)
+- **THEN** `tasks` SHALL become `ready` and `openspec instructions tasks` SHALL proceed normally
+
+### Requirement: Prototype artifact requires design
+The `prototype` artifact's `requires` list SHALL include `design`, ensuring prototype is created after design decisions are captured.
+
+#### Scenario: Prototype blocked without design
+- **WHEN** a change's `design` artifact has not been created
+- **THEN** `prototype` SHALL show as `blocked`
+
+### Requirement: Prototype artifact content for UI changes
+For changes involving UI components, pages, or visual interaction, the `prototype.md` artifact SHALL reference HTML prototype files from `docs/prototypes/` and capture key design decisions refined during visual iteration.
+
+#### Scenario: UI change prototype artifact
+- **WHEN** the change involves UI and HTML prototypes exist in `docs/prototypes/`
+- **THEN** `prototype.md` SHALL list each prototype file path, summarize the visual direction, and reference the design decisions confirmed during explore
+
+#### Scenario: UI change without HTML prototype
+- **WHEN** the change involves UI but no HTML prototype was created during explore
+- **THEN** `prototype.md` SHALL state that no prototype was generated and include a brief visual direction description based on design.md
+
+### Requirement: Prototype artifact content for non-UI changes
+For changes that do not involve UI, the `prototype.md` artifact SHALL contain a stub stating no prototype is needed with a one-line rationale.
+
+#### Scenario: Non-UI change prototype stub
+- **WHEN** the change is backend-only, config, or refactoring with no UI impact
+- **THEN** `prototype.md` SHALL contain a "No prototype needed" section with a brief reason (e.g., "backend-only change affecting X module")
+
+### Requirement: Unconditional explore to propose flow
+The explore command SHALL always direct the user to `/opsx:propose` as the next step after exploration. The explore command SHALL NEVER suggest `/opsx:apply` directly.
+
+#### Scenario: Explore ending with prototype
+- **WHEN** explore completes and an HTML prototype was created in `docs/prototypes/`
+- **THEN** the explore command SHALL say to run `/opsx:propose` next, mentioning the prototype will be incorporated
+
+#### Scenario: Explore ending without prototype
+- **WHEN** explore completes and no prototype was created
+- **THEN** the explore command SHALL say to run `/opsx:propose` next
+
+### Requirement: Propose command prototype awareness
+The propose command SHALL check `docs/prototypes/` for HTML prototype files matching the change name before creating the prototype artifact.
+
+#### Scenario: Propose finds prototype HTML
+- **WHEN** propose runs and `docs/prototypes/` contains HTML files matching the change name
+- **THEN** propose SHALL read those files and use them as design source-of-truth when creating the prototype artifact
+
+#### Scenario: Propose finds no prototype HTML
+- **WHEN** propose runs and no matching HTML prototypes exist
+- **THEN** propose SHALL create a non-UI stub prototype artifact (if the change has no UI impact) or offer to generate a prototype first (if the change has UI impact)
+

--- a/openspec/specs/file-tracker/spec.md
+++ b/openspec/specs/file-tracker/spec.md
@@ -1,5 +1,7 @@
-## ADDED Requirements
+## Purpose
 
+Provide a per-message file path registry (FileTracker) that synchronizes bidirectionally with editor text markers and supports both TUI and Web UI drag-and-drop file attachment workflows.
+## Requirements
 ### Requirement: FileTracker manages per-message attached file paths
 The system SHALL provide a `FileTracker` class that maintains a registry of file paths attached to the current message, independent of the editor text content.
 
@@ -110,17 +112,49 @@ The TUI SHALL display a status line indicating the number of currently tracked f
 - **AND** the status line SHALL update accordingly
 
 ### Requirement: submit with fileRefs passes fileRefs independently from text
-When the user submits a message, the system SHALL pass tracked file paths as a separate `fileRefs` array, not embedded in the `text` field.
+When the user submits a message, the system SHALL pass tracked file paths as a separate `fileRefs` array. Image files SHALL be processed through `resolveFileRefs` and enter ImagePipeline. Non-image files SHALL be injected as absolute path references into the prompt text without reading file contents.
 
-#### Scenario: Web UI submit with fileRefs
-- **WHEN** user submits a message in the Web UI with tracked files
-- **THEN** the WebSocket command SHALL include `fileRefs` array with absolute paths from the tracker
+#### Scenario: Web UI submit with uploaded files (non-image)
+- **WHEN** user drags non-image files into the Web UI and submits
+- **THEN** the WebSocket command SHALL include `uploadedFiles` array with `{ name, content }` objects
+- **AND** the `fileRefs` field SHALL NOT be used for web drag-and-drop
 - **AND** the `text` field SHALL contain only the user's typed message text
 
-#### Scenario: TUI submit with fileRefs
-- **WHEN** user presses Enter in the TUI with tracked files
-- **THEN** the submission SHALL include the fileRefs from the tracker
-- **AND** the text SHALL contain only the editor content
+#### Scenario: Web UI submit with dropped images
+- **WHEN** user drags image files into the Web UI and submits
+- **THEN** the images SHALL be read as base64 via FileReader in the browser
+- **AND** the base64 data SHALL be sent in the `images` field (same as paste behavior)
+- **AND** the image SHALL NOT go through `resolveFileRefs` on the server
+
+#### Scenario: Web backend writes uploaded files to temp directory
+- **WHEN** the Web backend receives `uploadedFiles` in a chat command
+- **THEN** each file SHALL be written to `.dscode/uploads/<session-id>/<timestamp>-<filename>`
+- **AND** the temp paths SHALL be injected into the prompt as `📁 Attached files:\n- \`/project/.dscode/uploads/...\``
+- **AND** the Agent CAN read the files via `read_file` on the temp paths
+
+#### Scenario: Web UI drop with mixed image and non-image files
+- **WHEN** user drags both image and non-image files into the Web UI and submits
+- **THEN** images SHALL go into `images` field as base64
+- **AND** non-images SHALL go into `uploadedFiles` field with content
+- **AND** both SHALL appear in the Agent prompt (images via ImagePipeline, non-images via temp path references)
+
+#### Scenario: TUI submit with fileRefs containing images
+- **WHEN** user presses Enter in the TUI with tracked image files
+- **THEN** the submission SHALL include the image fileRefs from the tracker
+- **AND** the image files SHALL be processed through `resolveFileRefs` and enter ImagePipeline
+- **AND** the editor text content SHALL be preserved as user message text
+
+#### Scenario: TUI submit with fileRefs containing non-image files
+- **WHEN** user presses Enter in the TUI with tracked non-image files
+- **THEN** the absolute paths SHALL be injected into the prompt as path references (e.g., `📁 Attached files:\n- \`/abs/path/file.ts\``)
+- **AND** `resolveFileRefs` SHALL NOT be called for non-image files
+- **AND** the file contents SHALL NOT be read
+
+#### Scenario: TUI submit with mixed image and non-image fileRefs
+- **WHEN** user presses Enter in the TUI with both image and non-image tracked files
+- **THEN** image files SHALL go through `resolveFileRefs` → ImagePipeline
+- **AND** non-image files SHALL be injected as path references only
+- **AND** both image descriptions and path references SHALL appear in the Agent prompt
 
 #### Scenario: Submit with no tracked files
 - **WHEN** user submits a message with no tracked files
@@ -131,3 +165,4 @@ When the user submits a message, the system SHALL pass tracked file paths as a s
 - **WHEN** a message is submitted
 - **THEN** the tracker SHALL be cleared (via `drain()`)
 - **AND** the chips/status line SHALL be cleared
+

--- a/openspec/specs/image-pipeline-compressed/spec.md
+++ b/openspec/specs/image-pipeline-compressed/spec.md
@@ -1,0 +1,56 @@
+# image-pipeline-compressed Specification
+
+## Purpose
+TBD - created by archiving change fix-image-pipeline-uncompressed-images. Update Purpose after archive.
+## Requirements
+### Requirement: ImagePipeline SHALL pass compressed cached images to vision model
+After `ImageCache.put()` compresses all images and returns `cachedRefs`, the pipeline SHALL read the compressed images back via `ImageCache.get()` and pass the compressed `ImageContent[]` to `describeImagesViaVisionModel()` instead of the original uncompressed images.
+
+#### Scenario: Large JPEG image goes through vision model with compressed data
+- **WHEN** a user submits a 871KB JPEG image through TUI drag-and-drop
+- **AND** sharp is available for compression
+- **THEN** `ImageCache.put()` SHALL compress the image to ≤480px height PNG and cache it
+- **AND** the pipeline SHALL read the compressed image back via `ImageCache.get()`
+- **AND** the compressed image SHALL be passed to `describeImagesViaVisionModel()`
+- **AND** the vision model SHALL receive the compressed PNG data, not the original 871KB JPEG base64
+
+#### Scenario: Small image that doesn't need resize
+- **WHEN** a user submits a small image (≤480px height)
+- **AND** sharp is available
+- **THEN** `ImageCache.put()` SHALL convert it to PNG without resizing
+- **AND** the pipeline SHALL still pass the cached (converted) version to the vision model
+
+### Requirement: ImagePipeline SHALL pass compressed cached images to OCR fallback
+When the vision model call fails and the pipeline falls back to OCR, it SHALL pass the compressed `ImageContent[]` (read from cache via `ImageCache.get()`) to `ocrImages()` instead of the original uncompressed images.
+
+#### Scenario: Vision model fails, OCR receives compressed image
+- **WHEN** `describeImagesViaVisionModel()` throws an error or returns empty
+- **AND** the pipeline enters the OCR fallback path
+- **THEN** the compressed images from cache SHALL be passed to `ocrImages()`
+- **AND** OCR SHALL run on the 480px PNG version, not the original high-resolution image
+
+### Requirement: Readback failure SHALL fall back to original images
+If any `ImageCache.get(cachedRef)` returns `null` (cache miss), the pipeline SHALL fall back to using the original uncompressed images for the downstream call.
+
+#### Scenario: Cache file deleted between put and get
+- **WHEN** `ImageCache.put()` succeeds and returns a valid `ImageRef`
+- **BUT** the cached file is deleted from disk before `ImageCache.get()` reads it
+- **THEN** `ImageCache.get()` SHALL return `null`
+- **AND** the pipeline SHALL fall back to using the original `normalizedImages`
+- **AND** the pipeline SHALL NOT crash or throw
+
+#### Scenario: Sharp not available, original images used
+- **WHEN** sharp is not installed
+- **AND** `ImageCache.put()` stores the original uncompressed data
+- **THEN** `ImageCache.get()` SHALL return the same uncompressed data
+- **AND** the pipeline SHALL pass it to the vision model and OCR (no regression from current behavior)
+
+### Requirement: Batch readback SHALL be parallel
+All `ImageCache.get()` calls for a batch of images SHALL be issued in parallel via `Promise.all` before the first downstream call.
+
+#### Scenario: Multiple images submitted together
+- **WHEN** a user submits 3 images in a single message
+- **AND** all 3 are compressed and cached by `ImageCache.put()`
+- **THEN** all 3 SHALL be read back from cache in parallel via `Promise.all`
+- **AND** the compressed array SHALL be passed to the vision model as a single batch
+

--- a/openspec/specs/tui-file-drop-path-ref/spec.md
+++ b/openspec/specs/tui-file-drop-path-ref/spec.md
@@ -1,0 +1,48 @@
+# tui-file-drop-path-ref Specification
+
+## Purpose
+TBD - created by archiving change fix-tui-file-drag-drop. Update Purpose after archive.
+## Requirements
+### Requirement: Non-image drag-drop files inject path references only
+When non-image files are attached via drag-and-drop and the user submits the message, the system SHALL inject only absolute path references into the Agent prompt, without reading the file contents.
+
+#### Scenario: Submit with one non-image file
+- **WHEN** user drags `/Users/x/Downloads/config.json` into the TUI and submits with text "check this"
+- **THEN** the Agent prompt SHALL contain `📁 Attached files:\n- \`/Users/x/Downloads/config.json\``
+- **AND** the file content SHALL NOT be read or injected into the prompt
+- **AND** the prompt SHALL also contain the user's text "check this"
+
+#### Scenario: Submit with multiple non-image files
+- **WHEN** user drags `/tmp/a.ts`, `/tmp/b.json`, `/tmp/c.md` into the TUI and submits
+- **THEN** the Agent prompt SHALL contain a path reference for each file on separate lines
+- **AND** no file contents SHALL be read
+
+#### Scenario: Submit with mixed image and non-image files
+- **WHEN** user drags `photo.png`, `config.json`, `types.ts` into the TUI and submits
+- **THEN** the image file (`photo.png`) SHALL be processed through `resolveFileRefs` and enter the ImagePipeline as normal
+- **AND** the non-image files (`config.json`, `types.ts`) SHALL appear as path references only
+- **AND** the path references SHALL use the absolute file path
+
+#### Scenario: Submit with only non-image files and no user text
+- **WHEN** user drags `config.json` into the TUI and submits without typing any text
+- **THEN** the Agent prompt SHALL contain the path reference
+- **AND** the prompt SHALL NOT be empty or rejected
+
+#### Scenario: Non-image file has been deleted since drop
+- **WHEN** user drags a file that was subsequently deleted from disk and submits
+- **THEN** the path reference SHALL still be injected (the path string itself is valid)
+- **AND** the Agent will receive a "not found" error if it attempts to `read_file`
+
+### Requirement: Image drag-drop files continue to use ImagePipeline
+When image files are attached via drag-and-drop, the system SHALL continue to process them through the existing `resolveFileRefs` → ImagePipeline flow, unchanged from current behavior.
+
+#### Scenario: Submit with only image files
+- **WHEN** user drags `photo.png` into the TUI and submits
+- **THEN** the image SHALL be read and processed through ImagePipeline
+- **AND** the Agent prompt SHALL contain the image description (via `<image_description>`)
+
+#### Scenario: Image file with non-native-image-support model
+- **WHEN** user drags `photo.jpg` and the current model does not support native image input
+- **THEN** the image SHALL go through the vision model or OCR fallback as normal
+- **AND** the Agent SHALL NOT receive raw base64 in the prompt
+

--- a/openspec/specs/web-frontend/spec.md
+++ b/openspec/specs/web-frontend/spec.md
@@ -1,9 +1,7 @@
 ## Purpose
 
 Defines the visual and behavioral requirements for the dscode web frontend, including design language, themes, session management, processing indicators, permission dialogs, transitions, and message rendering.
-
 ## Requirements
-
 ### Requirement: Warm design language
 All frontend components SHALL use the warm design system tokens defined in the `warm-design-system` spec. Every component MUST reference semantic CSS custom properties for colors and follow the typography and shape language specifications.
 
@@ -187,7 +185,6 @@ ChatView SHALL expose a ref to its scroll container so TransitionCanvas can prog
 - **THEN** ChatView SHALL forward a `scrollContainerRef` (React ref to the scrollable DOM element) to TransitionCanvas
 - **AND** TransitionCanvas SHALL use this ref to save/restore scroll position and set `overflow: hidden` during animation
 
-
 ### Requirement: Dashboard mode disabled when session has no messages
 The `ViewModeSwitcher` component SHALL disable the "Dashboard" option when the current session has no messages (`messages.length === 0`). The "Chat" option SHALL remain selectable. The disabled option SHALL use the HTML `disabled` attribute on the `<option>` element.
 
@@ -237,8 +234,6 @@ The `ThinkingBlock` component SHALL render as a `<div class="thinking">` with a 
 #### Scenario: Thinking label with dot indicator
 - **WHEN** thinking content renders
 - **THEN** a label row with "Thinking" uppercase text and a 5px amber dot SHALL appear above the content
-
-
 
 ### Requirement: Theme support
 The frontend SHALL support warm light and warm dark themes using warm stone/taupe gray neutrals (not cream/beige). The initial theme defaults to warm light. Dark mode uses warm deep gray-brown tones instead of cold blue-grays.
@@ -389,8 +384,9 @@ The frontend SHALL provide a text input area at the bottom of the screen with fl
 
 #### Scenario: Slash command text submitted as chat
 - **WHEN** user submits text starting with `/` (e.g., `/help`, `/config key value`, or `/Users/foo/bar.ts`)
+
 ### Requirement: Session list shows running indicator
-The session list in the sidebar SHALL render a rotating spinner icon for the session that is currently active and processing. It SHALL NOT render any other visual indicator (no accent left border, no colored dot) for the active session. The indicator SHALL be driven by `isProcessing` and `currentSessionId` from the `sessions` server event.
+The session list in the sidebar SHALL render a rotating spinner icon for the session that is currently active and processing. The indicator SHALL be driven by `isProcessing` and `currentSessionId` from the `sessions` server event.
 
 #### Scenario: Running indicator visible
 - **WHEN** the frontend receives a `sessions` event with `currentSessionId: "A"`, `isProcessing: true`, and session A is in the list
@@ -403,14 +399,6 @@ The session list in the sidebar SHALL render a rotating spinner icon for the ses
 #### Scenario: Running indicator scoped to current session only
 - **WHEN** `currentSessionId` is "A" and `isProcessing` is true
 - **THEN** only session A's row shows the spinner; other session rows (B, C) do not
-
-#### Scenario: No accent border or colored dot on active session
-- **WHEN** any session row is rendered as the active session
-- **THEN** it does NOT render a left-side accent border (`borderLeft: 3px solid`) nor a colored dot indicator; only the `accent-bg` background and the Spinner (when processing) distinguish the active session
-The frontend SHALL support attaching images to messages via paste from clipboard, with flat, warm-toned thumbnail previews.
-
-#### Scenario: Paste image from clipboard
-- **WHEN** user pastes image data (Ctrl+V / Cmd+V) while input is focused
 
 ### Requirement: Session list shows running indicator
 The session list in the sidebar SHALL render a rotating spinner icon for the session that is currently active and processing. The indicator SHALL be driven by `isProcessing` and `currentSessionId` from the `sessions` server event.
@@ -448,7 +436,6 @@ The frontend SHALL store the `currentSessionId` received from each `sessions` ev
 
 ---
 
-
 ### Requirement: Artifact events handled in App
 The App component SHALL handle `artifact_start`, `artifact_delta`, and `artifact_end` server events, accumulating the delta content and passing it to the `ArtifactContainer` component.
 
@@ -479,3 +466,32 @@ The frontend SHALL provide an `ArtifactContainer` component that renders an `<if
 #### Scenario: ArtifactContainer with no content
 - **WHEN** `ArtifactContainer` receives `loading={false}` and empty `html`
 - **THEN** it displays "Waiting for dashboard generation..." in muted text
+
+### Requirement: Message timestamp display
+The frontend SHALL display the real creation time of each chat message in the meta line, formatted via the browser's locale-aware time formatting, and SHALL gracefully omit the time portion when a message has no timestamp.
+
+#### Scenario: User message shows real timestamp
+- **WHEN** a user message has `message.createdAt` set to a valid epoch millisecond value
+- **THEN** the `UserBubble` meta line SHALL display `"You · HH:MM AM/PM"` (locale-dependent) using `new Date(message.createdAt).toLocaleTimeString()`
+- **AND** the time string SHALL reflect the actual message creation time, not a hardcoded value
+
+#### Scenario: Assistant message shows real timestamp
+- **WHEN** an assistant message has `message.createdAt` set to a valid epoch millisecond value
+- **THEN** the `AssistantMessage` meta line SHALL display `"dscode · HH:MM AM/PM"` (locale-dependent) using `new Date(message.createdAt).toLocaleTimeString()`
+- **AND** the time string SHALL reflect the actual message creation time, not a hardcoded value
+
+#### Scenario: Message without timestamp omits time
+- **WHEN** a message has `message.createdAt` undefined or absent (e.g., legacy history messages)
+- **THEN** the meta line SHALL display only the role label (`"You"` for user, `"dscode"` for assistant) without the time separator or time string
+- **AND** no "09:41" or any hardcoded time string SHALL be displayed
+
+#### Scenario: Timestamp updates as new messages arrive
+- **WHEN** a new message is created during an active session
+- **THEN** its `createdAt` SHALL reflect the wall-clock time at creation
+- **AND** the displayed time SHALL differ from the time shown on previously created messages
+
+#### Scenario: All hardcoded time strings removed
+- **WHEN** the ChatView renders any message bubble (`UserBubble` or `AssistantMessage`)
+- **THEN** no hardcoded time string (such as `"09:41"`) SHALL appear anywhere in the meta line
+- **AND** all time values SHALL derive from `message.createdAt`
+

--- a/openspec/specs/web-upload-cache/spec.md
+++ b/openspec/specs/web-upload-cache/spec.md
@@ -1,0 +1,90 @@
+# web-upload-cache Specification
+
+## Purpose
+TBD - created by archiving change fix-file-upload-cache. Update Purpose after archive.
+## Requirements
+### Requirement: Settings panel displays upload cache size
+The Settings panel SHALL display the total size of uploaded files stored in `.dscode/uploads/`, along with file count and session count. The cache size SHALL be queried from the server each time the Settings tab becomes active.
+
+#### Scenario: Cache block shows size, file count, and session count
+- **WHEN** the user opens the Settings panel
+- **THEN** the Upload Cache block SHALL query the server for cache statistics
+- **AND** display total size in human-readable format (e.g., "47 MB")
+- **AND** display file count and session count (e.g., "23 files · 5 sessions")
+
+#### Scenario: Cache block shows zero state
+- **WHEN** the server reports 0 bytes of cache
+- **THEN** the cache size SHALL display "0 B"
+- **AND** the subtext SHALL display "no cached files"
+- **AND** the Clear button SHALL be disabled
+
+#### Scenario: Cache block shows loading state
+- **WHEN** the Settings tab becomes active and the cache size query is in flight
+- **THEN** the cache block SHALL display "..." as the size
+- **AND** the subtext SHALL indicate a loading state (e.g., "calculating...")
+- **AND** the Clear button SHALL be disabled during loading
+
+#### Scenario: Cache block shows warning for large cache
+- **WHEN** the server reports cache total exceeding 40 MB
+- **THEN** the cache block SHALL receive a visual warning treatment (danger border color using `--color-error-text`)
+- **AND** the helper text SHALL change to "Consider clearing to free disk space"
+
+#### Scenario: Cache block uses design tokens
+- **WHEN** the cache block renders
+- **THEN** it SHALL use semantic `--color-*` CSS custom properties for all colors
+- **AND** the cache size SHALL use mono font (Geist Mono)
+- **AND** labels SHALL use the muted text color token
+
+### Requirement: User can clear upload cache
+The Settings panel SHALL provide a Clear button that sends a command to the server to delete all uploaded files in `.dscode/uploads/`. The UI SHALL reflect the clearing state and update upon completion.
+
+#### Scenario: Clicking Clear deletes all uploads
+- **WHEN** the user clicks the Clear button
+- **THEN** a `{ type: "cache", action: "clear" }` command SHALL be sent to the server
+- **AND** the cache block SHALL enter a clearing state showing "..." with the Clear button disabled
+- **AND** upon receiving the updated `cache_size` event, the block SHALL update to show zero
+
+#### Scenario: Clear button disabled when cache is empty
+- **WHEN** the cache size is 0
+- **THEN** the Clear button SHALL be disabled
+
+#### Scenario: Clear button enabled when cache is non-empty
+- **WHEN** the cache size is greater than 0
+- **THEN** the Clear button SHALL be enabled
+
+### Requirement: Server provides cache statistics endpoint
+The WebSocket server SHALL support a `{ type: "cache", action: "size" }` client command and respond with a `{ type: "cache_size", totalBytes, fileCount, sessionCount }` server event. The server SHALL recursively scan the `<project>/.dscode/uploads/` directory.
+
+#### Scenario: Server responds with cache statistics
+- **WHEN** the server receives `{ type: "cache", action: "size" }`
+- **THEN** it SHALL scan `.dscode/uploads/` for all files across all session subdirectories
+- **AND** respond with `{ type: "cache_size", totalBytes: number, fileCount: number, sessionCount: number }`
+
+#### Scenario: Server handles missing upload directory
+- **WHEN** the `.dscode/uploads/` directory does not exist
+- **THEN** the server SHALL respond with `{ type: "cache_size", totalBytes: 0, fileCount: 0, sessionCount: 0 }`
+
+### Requirement: Server clears upload cache on command
+The WebSocket server SHALL support a `{ type: "cache", action: "clear" }` client command. It SHALL remove all files and directories under `.dscode/uploads/` and respond with an updated `cache_size` event showing zero.
+
+#### Scenario: Clear removes all upload directories
+- **WHEN** the server receives `{ type: "cache", action: "clear" }`
+- **THEN** it SHALL recursively delete all contents of `.dscode/uploads/`
+- **AND** respond with `{ type: "cache_size", totalBytes: 0, fileCount: 0, sessionCount: 0 }`
+
+#### Scenario: Clear when directory is already empty
+- **WHEN** the upload directory does not exist or is empty
+- **THEN** the clear operation SHALL complete without error
+- **AND** respond with `{ type: "cache_size", totalBytes: 0, fileCount: 0, sessionCount: 0 }`
+
+### Requirement: Session deletion cleans up upload cache
+When a session is deleted, the server SHALL also delete the corresponding upload directory at `.dscode/uploads/<sessionId>/`.
+
+#### Scenario: Deleting session removes its upload files
+- **WHEN** a session is deleted
+- **THEN** the server SHALL call `cleanupUploadDir(sessionId)` to remove `.dscode/uploads/<sessionId>/`
+
+#### Scenario: Deleting session without uploads is safe
+- **WHEN** a session is deleted but `.dscode/uploads/<sessionId>/` does not exist
+- **THEN** the cleanup SHALL not throw or produce an error
+

--- a/openspec/specs/web-upload-temp-file/spec.md
+++ b/openspec/specs/web-upload-temp-file/spec.md
@@ -1,0 +1,166 @@
+# web-upload-temp-file Specification
+
+## Purpose
+TBD - created by archiving change fix-tui-file-drag-drop. Update Purpose after archive.
+## Requirements
+### Requirement: Web drag-and-drop uploads file content to server temp directory
+
+When files are dragged-and-dropped into the Web UI, the browser SHALL read the file content via `FileReader` and transmit it to the server. The server SHALL write non-image files to a temporary directory and inject temp paths into the Agent prompt. Image files SHALL be sent as base64 in the `images` field, consistent with paste behavior.
+
+#### Scenario: Drop a single non-image file in Web UI
+- **WHEN** user drags `config.json` into the Web UI and submits with text "check this"
+- **THEN** the browser SHALL read the file content via `FileReader.readAsText()`
+- **AND** the WebSocket chat command SHALL include `uploadedFiles: [{ name: "config.json", content: "<file contents>" }]`
+- **AND** the server SHALL write the content to `.dscode/uploads/<session-id>/<timestamp>-config.json`
+- **AND** the Agent prompt SHALL contain `📁 Attached files:\n- \`<project>/.dscode/uploads/<session-id>/<timestamp>-config.json\``
+- **AND** the Agent CAN read the temp file via `read_file`
+
+#### Scenario: Drop multiple non-image files in Web UI
+- **WHEN** user drags `a.ts`, `b.json`, `c.md` into the Web UI and submits
+- **THEN** all three files SHALL be read and transmitted in `uploadedFiles`
+- **AND** each SHALL be written to a separate temp file with unique timestamp prefix
+- **AND** each temp path SHALL appear in the 📁 Attached files block
+
+#### Scenario: Drop image files in Web UI
+- **WHEN** user drags `photo.png` into the Web UI and submits
+- **THEN** the browser SHALL read the image via `FileReader.readAsDataURL()`
+- **AND** the image base64 SHALL be sent in the `images` field (NOT `fileRefs`)
+- **AND** the image SHALL enter ImagePipeline on the server
+- **AND** the server SHALL NOT call `resolveFileRefs` for browser-dropped images
+
+#### Scenario: Drop mixed image and non-image files in Web UI
+- **WHEN** user drags `photo.png`, `config.json`, `types.ts` into the Web UI and submits
+- **THEN** `photo.png` SHALL be in `images` field as base64
+- **AND** `config.json` and `types.ts` SHALL be in `uploadedFiles` field with content
+- **AND** the image SHALL go through ImagePipeline
+- **AND** the non-image files SHALL be written to temp paths and referenced in prompt
+
+#### Scenario: Drop only non-image files with no user text in Web UI
+- **WHEN** user drags `config.json` into the Web UI and submits without typing any text
+- **THEN** the prompt SHALL contain the temp path reference
+- **AND** the prompt SHALL NOT be empty or rejected
+
+#### Scenario: Non-image file exceeds size limit for upload (no project match)
+- **WHEN** user drags a file exceeding `maxFileSize` (from atFile config)
+- **THEN** the browser SHALL check size before reading and skip the file
+- **AND** a warning toast SHALL be shown to the user
+
+#### Scenario: Total uploaded size exceeds limit in Web UI
+- **WHEN** user drags files whose combined size exceeds `maxTotalSize` (from atFile config)
+- **THEN** the browser SHALL skip files beyond the limit
+- **AND** a warning toast SHALL be shown
+
+#### Scenario: Temp file cleanup on session end
+- **WHEN** a session ends or is compacted
+- **THEN** the `.dscode/uploads/<session-id>/` directory SHALL be cleaned up
+- **AND** temp files from other sessions SHALL NOT be affected
+
+### Requirement: Web UI handleDrop mirrors handlePaste semantics
+
+The drag-and-drop handler in the Web UI (`handleDrop`) SHALL use the same `FileReader`-based approach as `handlePaste`, reading file content in the browser rather than attempting to extract filesystem paths.
+
+#### Scenario: handleDrop reads file content
+- **WHEN** files are dropped into the MessageInput area
+- **THEN** the handler SHALL iterate over `e.dataTransfer.files`
+- **AND** for each image file, SHALL call `fileToImageAttachment()` to get base64
+- **AND** for each non-image file, SHALL call `FileReader.readAsText()` to get content
+- **AND** SHALL NOT attempt to read `(file as any).path`
+
+#### Scenario: handleDrop does not use FileTracker for content
+- **WHEN** files are dropped into the Web UI
+- **THEN** the FileTracker SHALL NOT be used to track dropped files
+- **AND** image base64 data SHALL be stored in the existing `images` state
+- **AND** non-image content SHALL be stored in a new `uploadedFiles` state
+
+### Requirement: ClientCommand protocol supports uploaded file content
+
+The WebSocket `chat` command SHALL support a new `uploadedFiles` field for transmitting file content from browser to server.
+
+#### Scenario: Chat command includes uploadedFiles
+- **WHEN** the Web UI sends a chat command with uploaded non-image files
+- **THEN** the command SHALL include `uploadedFiles: { name: string; content: string }[]`
+- **AND** `content` SHALL be the UTF-8 text content of the file
+- **AND** `name` SHALL be the original filename (for display and temp path generation)
+
+#### Scenario: Chat command without uploaded files
+- **WHEN** the Web UI sends a chat command with no uploaded files
+- **THEN** the `uploadedFiles` field SHALL be omitted or an empty array
+- **AND** behavior SHALL be identical to before this change
+
+### Requirement: Dragged project files resolve as @path references
+
+When a non-image file is dragged into the Web UI and its filename matches a file in the project directory tree, the system SHALL inject it as a `@path` reference rather than reading the file content. This achieves zero-size-limit "link" semantics for project files, matching TUI behavior.
+
+#### Scenario: Single project file — unique name match
+- **WHEN** user drags `config.json` into the Web UI and the project has exactly one file named `config.json` at `src/lib/config.json`
+- **THEN** the browser SHALL search the project file tree for matching files (via the existing `file_list` command)
+- **AND** the file SHALL be injected as `@src/lib/config.json` in the input text
+- **AND** the file content SHALL NOT be read or transmitted
+- **AND** the Agent SHALL receive the @path reference and can `read_file` the original file directly
+
+#### Scenario: Multiple project files with same name — picker fallback
+- **WHEN** user drags `config.json` and the project has `src/config.json` and `tests/config.json`
+- **THEN** a file picker popover SHALL appear (reusing the existing `showFileMenu` UI component)
+- **AND** the user SHALL select one file from the list
+- **AND** the selected file SHALL be injected as `@<selected-path>`
+- **AND** no file content SHALL be read or transmitted
+
+#### Scenario: External file — no project match
+- **WHEN** user drags `desktop-file.pdf` and no project file has that name
+- **THEN** the system SHALL fall back to the existing upload-to-temp-directory flow
+- **AND** the file content SHALL be read and transmitted to the server
+
+#### Scenario: Project file with ambiguous name — user cancels picker
+- **WHEN** user drags a file with multiple project matches and dismisses the picker (Escape or click outside)
+- **THEN** the file SHALL be dropped silently (no upload, no error)
+
+### Requirement: File size limits are config-driven
+
+The drag-and-drop size limits SHALL be driven by server config rather than hardcoded constants. The browser SHALL receive `maxFileSize` and `maxTotalSize` values from the server (via the `config` or `ready` event) and apply them before reading file content.
+
+#### Scenario: Size limits received from server
+- **WHEN** the Web UI connects and receives `config` event
+- **THEN** the config SHALL include `maxFileSize` and `maxTotalSize` values
+- **AND** the browser SHALL use these values for size checks, NOT hardcoded constants
+
+#### Scenario: Non-image file exceeds maxFileSize
+- **WHEN** user drags a non-image file exceeding `maxFileSize` (and the file has no project match)
+- **THEN** the browser SHALL skip the file before reading its content
+- **AND** a warning toast SHALL be shown: "Skipped filename.ext (exceeds X MB limit)"
+
+#### Scenario: Combined upload exceeds maxTotalSize
+- **WHEN** user drags multiple files whose combined size exceeds `maxTotalSize`
+- **THEN** the browser SHALL skip files beyond the limit
+- **AND** a warning toast SHALL indicate how many files were skipped
+
+#### Scenario: Image files are NOT subject to size limits
+- **WHEN** user drags an image file of any size
+- **THEN** the image SHALL be processed through `fileToImageAttachment` → `compressImage` regardless of size
+- **AND** `maxFileSize` / `maxTotalSize` SHALL NOT apply to images
+
+### Requirement: Settings panel shows upload cache info and clear button
+
+The Settings panel in the Web UI sidebar SHALL display information about the upload cache (`.dscode/uploads/`) and provide a button to clear it.
+
+#### Scenario: Display upload cache stats
+- **WHEN** the Settings panel renders
+- **THEN** it SHALL show the current upload cache stats: number of files and total size (e.g., "Uploaded files: 5 files / 2.3 MB")
+- **AND** the stats SHALL be updated when the server sends `upload_stats` events
+
+#### Scenario: Clear upload cache
+- **WHEN** user clicks "Clear Upload Cache" button
+- **THEN** the browser SHALL send `{ type: "clear_uploads" }` to the server
+- **AND** the server SHALL delete all files in `.dscode/uploads/` recursively
+- **AND** the server SHALL respond with `{ type: "upload_stats", files: 0, bytes: 0 }`
+- **AND** a success toast SHALL be shown: "Cleared N files (X MB)"
+- **AND** the displayed stats SHALL update to 0 files / 0 B
+
+#### Scenario: Clear empty cache
+- **WHEN** user clicks "Clear Upload Cache" when `.dscode/uploads/` is empty or doesn't exist
+- **THEN** the server SHALL respond with `{ type: "upload_stats", files: 0, bytes: 0 }`
+- **AND** an info toast SHALL be shown: "No cached files to clear"
+
+#### Scenario: Upload stats sent on startup
+- **WHEN** the server starts or a client connects
+- **THEN** the server SHALL scan `.dscode/uploads/` and send the current stats via `{ type: "upload_stats", files: N, bytes: M }`
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "dscode": "dist/dscode.mjs"
       },
       "devDependencies": {
+        "@fission-ai/openspec": "^1.5.0",
         "@types/node": "^22.9.0",
         "@types/pngjs": "^6.0.5",
         "@types/sharp": "^0.31.1",
@@ -1045,6 +1046,32 @@
         "node": ">=18"
       }
     },
+    "node_modules/@fission-ai/openspec": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@fission-ai/openspec/-/openspec-1.5.0.tgz",
+      "integrity": "sha512-SLZkyF51gFYkISufZKaka0X04z4y/WCjPOcCB+EC7tALd0TC+7V76BOIzWOSIOhdhBWwh5EMIBhrgLnugIh1DA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/prompts": "^7.10.1",
+        "chalk": "^5.5.0",
+        "commander": "^14.0.0",
+        "cross-spawn": "7.0.6",
+        "fast-glob": "^3.3.3",
+        "ora": "^8.2.0",
+        "posthog-node": "^5.20.0",
+        "yaml": "^2.8.2",
+        "zod": "^4.0.17"
+      },
+      "bin": {
+        "openspec": "bin/openspec.js"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
     "node_modules/@google/genai": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
@@ -1583,6 +1610,356 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@inquirer/ansi": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.2.tgz",
+      "integrity": "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/checkbox": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.3.2.tgz",
+      "integrity": "sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "5.1.21",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.21.tgz",
+      "integrity": "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "10.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.2.tgz",
+      "integrity": "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^2.0.0",
+        "signal-exit": "^4.1.0",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/editor": {
+      "version": "4.2.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.23.tgz",
+      "integrity": "sha512-aLSROkEwirotxZ1pBaP8tugXRFCxW94gwrQLxXfrZsKkfjOYC1aRvAZuhpJOb5cu4IBTJdsCigUlf2iCOu4ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/external-editor": "^1.0.3",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/expand": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.23.tgz",
+      "integrity": "sha512-nRzdOyFYnpeYTTR2qFwEVmIWypzdAx/sIkCMeTNTcflFOovfqUk+HcFhQQVBftAh9gmGrpFj6QcGEqrDMDOiew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/external-editor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
+      "integrity": "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^2.1.1",
+        "iconv-lite": "^0.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
+      "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/input": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.3.1.tgz",
+      "integrity": "sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/number": {
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.23.tgz",
+      "integrity": "sha512-5Smv0OK7K0KUzUfYUXDXQc9jrf8OHo4ktlEayFlelCjwMXz0299Y8OrI+lj7i4gCBY15UObk76q0QtxjzFcFcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/password": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.23.tgz",
+      "integrity": "sha512-zREJHjhT5vJBMZX/IUbyI9zVtVfOLiTO66MrF/3GFZYZ7T4YILW5MSkEYHceSii/KtRk+4i3RE7E1CUXA2jHcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/prompts": {
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.10.1.tgz",
+      "integrity": "sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/checkbox": "^4.3.2",
+        "@inquirer/confirm": "^5.1.21",
+        "@inquirer/editor": "^4.2.23",
+        "@inquirer/expand": "^4.0.23",
+        "@inquirer/input": "^4.3.1",
+        "@inquirer/number": "^3.0.23",
+        "@inquirer/password": "^4.0.23",
+        "@inquirer/rawlist": "^4.1.11",
+        "@inquirer/search": "^3.2.2",
+        "@inquirer/select": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/rawlist": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.11.tgz",
+      "integrity": "sha512-+LLQB8XGr3I5LZN/GuAHo+GpDJegQwuPARLChlMICNdwW7OwV2izlCSCxN6cqpL0sMXmbKbFcItJgdQq5EBXTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/search": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.2.2.tgz",
+      "integrity": "sha512-p2bvRfENXCZdWF/U2BXvnSI9h+tuA8iNqtUKb9UWbmLYCRQxd8WkvwWvYn+3NgYaNwdUkHytJMGG4MMLucI1kA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/select": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.4.2.tgz",
+      "integrity": "sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.10.tgz",
+      "integrity": "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -1641,6 +2018,44 @@
       ],
       "license": "MIT"
     },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
@@ -1667,6 +2082,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@posthog/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-Xk3JQ+cdychsvftrV3G9ZrN9W329lbyFW0pGJXFGKFQf8qr4upw2SgNg9BVorjSrfhoXZRnJGt/uNF4nGFBL5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.6"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -2344,6 +2769,35 @@
         "node": ">= 14"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -2395,6 +2849,19 @@
       "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
       "license": "MIT"
     },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
@@ -2423,12 +2890,103 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/chardet": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.2.0.tgz",
+      "integrity": "sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
@@ -2474,6 +3032,13 @@
       "dependencies": {
         "safe-buffer": "^5.0.1"
       }
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-module-lexer": {
       "version": "2.1.0",
@@ -2550,6 +3115,23 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
     "node_modules/fast-xml-builder": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
@@ -2585,6 +3167,16 @@
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
       }
     },
     "node_modules/fdir": {
@@ -2626,6 +3218,19 @@
       },
       "engines": {
         "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/formdata-polyfill": {
@@ -2695,6 +3300,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/google-auth-library": {
       "version": "10.6.2",
       "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
@@ -2747,6 +3365,23 @@
         "node": ">= 14"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/idb-keyval": {
       "version": "6.2.4",
       "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.4.tgz",
@@ -2762,11 +3397,87 @@
         "node": ">= 4"
       }
     },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-interactive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-url": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
       "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
       "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/jpeg-js": {
       "version": "0.4.4",
@@ -3101,6 +3812,36 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/log-symbols": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
+      "integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "is-unicode-supported": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-symbols/node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/long": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
@@ -3129,11 +3870,71 @@
         "node": ">= 18"
       }
     },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/mute-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.12",
@@ -3203,6 +4004,22 @@
       ],
       "license": "MIT"
     },
+    "node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/openai": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
@@ -3231,6 +4048,30 @@
       "license": "MIT",
       "bin": {
         "opencollective-postinstall": "index.js"
+      }
+    },
+    "node_modules/ora": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-8.2.0.tgz",
+      "integrity": "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "cli-cursor": "^5.0.0",
+        "cli-spinners": "^2.9.2",
+        "is-interactive": "^2.0.0",
+        "is-unicode-supported": "^2.0.0",
+        "log-symbols": "^6.0.0",
+        "stdin-discarder": "^0.2.2",
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-retry": {
@@ -3265,6 +4106,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/pathe": {
@@ -3332,6 +4183,19 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/posthog-node": {
+      "version": "5.21.2",
+      "resolved": "https://registry.npmjs.org/posthog-node/-/posthog-node-5.21.2.tgz",
+      "integrity": "sha512-Jehlu0KguL1LLyUczCt86OtA5INmeStK3zcgbv1BSyMcNxs0HP3GQogBrYhwhqHsk6JopiFFVpJyZEoXOUMhGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/core": "1.10.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/protobufjs": {
       "version": "7.6.1",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.1.tgz",
@@ -3356,11 +4220,49 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/regenerator-runtime": {
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
       "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
       "license": "MIT"
+    },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/retry": {
       "version": "0.13.1",
@@ -3369,6 +4271,17 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
       }
     },
     "node_modules/rolldown": {
@@ -3405,6 +4318,30 @@
         "@rolldown/binding-win32-x64-msvc": "1.0.2"
       }
     },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -3423,6 +4360,13 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/semver": {
@@ -3483,12 +4427,48 @@
         "@img/sharp-win32-x64": "0.34.5"
       }
     },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -3513,6 +4493,53 @@
       "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/stdin-discarder": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
+      "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
     },
     "node_modules/strnum": {
       "version": "2.3.0",
@@ -3612,6 +4639,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
       }
     },
     "node_modules/tr46": {
@@ -3870,6 +4910,22 @@
         "webidl-conversions": "^3.0.0"
       }
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -3882,6 +4938,66 @@
       },
       "bin": {
         "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
       },
       "engines": {
         "node": ">=8"
@@ -3936,6 +5052,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yoctocolors-cjs": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
+      "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/zlibjs": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "ws": "^8.21.0"
   },
   "devDependencies": {
+    "@fission-ai/openspec": "^1.5.0",
     "@types/node": "^22.9.0",
     "@types/pngjs": "^6.0.5",
     "@types/sharp": "^0.31.1",

--- a/src/drivers/vision/client.ts
+++ b/src/drivers/vision/client.ts
@@ -1,7 +1,10 @@
 import type { Api, Context, ImageContent, Model } from "@earendil-works/pi-ai";
 import { streamSimple, getEnvApiKey } from "../../models/index.js";
 import { resolveModel } from "../../models/index.js";
+import { Logger } from "../../utils/logger.js";
 import type { VisionConfig } from "./types.js";
+
+const _clog = new Logger({ type: "harness", id: process.env.DSCODE_RUNTIME_ID ?? "vision-client" });
 
 export interface ResolvedVisionModel {
   model: Model<Api>;
@@ -79,6 +82,8 @@ export async function describeImagesViaVisionModel(
     if (err instanceof DOMException && err.name === "AbortError") {
       throw err; // re-throw so pipeline can distinguish abort from failure
     }
+    const errMsg = err instanceof Error ? err.message : String(err);
+    _clog.warn("tool", "vision-client", `describeImages FAILED: ${errMsg}. images=${images.length}, totalBase64=${images.reduce((s, i) => s + (i.data?.length ?? 0), 0)}, img[0].mime=${images[0]?.mimeType ?? "?"}`);
     throw err;
   }
 }

--- a/src/drivers/vision/pipeline.ts
+++ b/src/drivers/vision/pipeline.ts
@@ -2,7 +2,10 @@ import type { ImageContent } from "@earendil-works/pi-ai";
 import { ImageCache } from "./cache.js";
 import { ocrImages } from "./ocr.js";
 import { resolveVisionModel, describeImagesViaVisionModel } from "./client.js";
+import { Logger } from "../../utils/logger.js";
 import type { VisionConfig, ImageRef, ProcessResult, ProcessOptions, ProgressFn } from "./types.js";
+
+const _plog = new Logger({ type: "harness", id: process.env.DSCODE_RUNTIME_ID ?? "pipeline" });
 
 export interface ImagePipelineConfig {
   visionConfig?: VisionConfig;
@@ -48,14 +51,22 @@ export class ImagePipeline {
     onProgress?.({ phase: "compressing", cachedRefs: [] });
     const cachedRefs = await Promise.all(normalizedImages.map((img) => ImageCache.put(img)));
     onProgress?.({ phase: "compressing", cachedRefs });
+
+    // Read compressed images back from cache for downstream use
+    const compressedRaw = await Promise.all(cachedRefs.map((ref) => ImageCache.get(ref)));
+    const compressedImages: ImageContent[] = compressedRaw.every((img): img is ImageContent => img !== null)
+      ? compressedRaw
+      : normalizedImages;
+
     if (signal?.aborted) throw new DOMException("The operation was aborted", "AbortError");
 
     // Try vision model
     const vision = resolveVisionModel(this.visionConfig, this.fallbackApiKey, this.onWarning);
+    _plog.info("tool", "image-pipeline", `vision resolved: ${vision ? `${vision.model.provider}/${vision.model.id}` : "null — falling to OCR"}, images=${normalizedImages.length}, img[0].dataLen=${normalizedImages[0]?.data?.length ?? 0}, mime=${normalizedImages[0]?.mimeType ?? "?"}`);
     if (vision) {
       try {
         onProgress?.({ phase: "describing", cachedRefs });
-        const description = await describeImagesViaVisionModel(normalizedImages, vision.model, vision.apiKey, signal);
+        const description = await describeImagesViaVisionModel(compressedImages, vision.model, vision.apiKey, signal);
         if (!description || description.trim().length === 0) {
           // Vision model returned empty description — fall through to OCR
           throw new Error("Vision model returned empty description");
@@ -69,15 +80,18 @@ export class ImagePipeline {
         if (err instanceof DOMException && err.name === "AbortError") {
           throw err; // re-throw abort immediately, no fallback
         }
-        this.onWarning(`Vision model failed: ${err instanceof Error ? err.message : String(err)}. Falling back to OCR.`);
+        const errMsg = err instanceof Error ? err.message : String(err);
+        _plog.warn("tool", "image-pipeline", `vision FAILED: ${errMsg}. img[0].dataLen=${normalizedImages[0]?.data?.length ?? 0}, mime=${normalizedImages[0]?.mimeType ?? "?"}, preview=${normalizedImages[0]?.data?.slice(0, 80) ?? "?"}`);
+        this.onWarning(`Vision model failed: ${errMsg}. Falling back to OCR.`);
       }
     }
 
     // OCR fallback
+    _plog.info("tool", "image-pipeline", `entering OCR fallback, images=${normalizedImages.length}`);
     if (signal?.aborted) throw new DOMException("The operation was aborted", "AbortError");
     try {
       onProgress?.({ phase: "ocr", cachedRefs });
-      const result = await ocrImages(normalizedImages, signal);
+      const result = await ocrImages(compressedImages, signal);
       onProgress?.({ phase: "done", cachedRefs });
       if (result.hasText) {
         const ocrText = text

--- a/src/ui/shared/reducer.ts
+++ b/src/ui/shared/reducer.ts
@@ -25,6 +25,7 @@ function updateLastOrCreate(
       tools: [],
       isStreaming: true,
       images: undefined,
+      createdAt: Date.now(),
       ...update({ id: "", role: "assistant" as const, content: "", thinking: "", tools: [] }),
     });
   }
@@ -40,6 +41,7 @@ export function conversationReducer(prev: UIMessage[], event: ServerEvent): UIMe
         content: normalizeContent(m.content),
         thinking: typeof m.thinking === "string" ? m.thinking : "",
         tools: Array.isArray(m.tools) ? m.tools : [],
+        createdAt: typeof m.createdAt === "number" ? m.createdAt : undefined,
         images: Array.isArray(m.images) ? m.images : [],
       }));
 
@@ -51,6 +53,7 @@ export function conversationReducer(prev: UIMessage[], event: ServerEvent): UIMe
           role: "user" as const,
           content: normalizeContent(event.text),
           images: (event as any).images ?? [],
+          createdAt: Date.now(),
         },
       ];
 

--- a/src/ui/shared/tool-result-formatter.ts
+++ b/src/ui/shared/tool-result-formatter.ts
@@ -6,7 +6,7 @@
  * is consistent regardless of which pipeline produces the output.
  */
 
-const DEFAULT_MAX_CHARS = 600;
+const DEFAULT_MAX_CHARS = 2000;
 
 /**
  * Extract a human-readable summary from write_file / overwrite_file results.

--- a/src/ui/shared/types.ts
+++ b/src/ui/shared/types.ts
@@ -182,6 +182,7 @@ export type ClientCommand =
   | { type: "mcp"; action: "list" | "refresh" | "connect" | "disconnect"; serverName?: string }
   | { type: "file_list"; prefix: string }
   | { type: "mcp_app"; action: "rpc"; appId: string; message: object }
+  | { type: "cache"; action: "size" | "clear" }
   | { type: "artifact"; action: "generate" | "update"; context?: string; instruction?: string };
 
 export type ServerEvent =
@@ -215,5 +216,6 @@ export type ServerEvent =
   | { type: "artifact_start" }
   | { type: "artifact_delta"; delta: string }
   | { type: "artifact_end" }
+  | { type: "cache_size"; totalBytes: number; fileCount: number; sessionCount: number }
   | { type: "mcp_open_browser" }
 

--- a/src/ui/shared/types.ts
+++ b/src/ui/shared/types.ts
@@ -141,6 +141,7 @@ export interface UIMessage {
   tools?: ToolCallEntry[];
   isStreaming?: boolean;
   images?: (ImageAttachment | ImageRef)[];
+  createdAt?: number; // epoch ms
 }
 // ── Permissions ──
 

--- a/src/ui/shared/types.ts
+++ b/src/ui/shared/types.ts
@@ -163,7 +163,7 @@ export interface PermOption {
 // ── Wire protocol ──
 
 export type ClientCommand =
-  | { type: "chat"; text: string; images?: ImageAttachment[]; clipboardImages?: ImageAttachment[]; fileRefs?: string[] }
+  | { type: "chat"; text: string; images?: ImageAttachment[]; clipboardImages?: ImageAttachment[]; fileRefs?: string[]; uploadedFiles?: { name: string; content: string }[] }
   | { type: "abort" }
   | { type: "permission"; decision: "allow" | "always_allow" | "always_allow_save" | "deny"; persistRule?: boolean; toolNamePattern?: string; fuzzyMode?: number; sessionGrantPattern?: string }
   | { type: "permission_response"; decision: "allow" | "always_allow" | "always_allow_save" | "deny"; denyReason?: string; toolNamePattern?: string }

--- a/src/ui/tui-app.ts
+++ b/src/ui/tui-app.ts
@@ -44,7 +44,7 @@ import { readClipboardImageNonBlocking } from "../utils/image.js";
 import { ImageManager } from "./image-manager.js";
 import { ImagePasteHandler } from "./image-paste-handler.js";
 import { FileTracker } from "./shared/file-tracker.js";
-import { resolveFileRefs } from "../utils/at-file-resolver.js";
+import { resolveFileRefs, isImagePath } from "../utils/at-file-resolver.js";
 import { existsSync } from "node:fs";
 import { resolve as resolvePath } from "node:path";
 // TuiDeps replaced by HarnessAPI — see src/core/harness-api.ts
@@ -1218,7 +1218,7 @@ export class TuiApp {
       return;
     }
 
-    if (!hasText && !hasImages) {
+    if (!hasText && !hasImages && !hasFiles) {
       const now = Date.now();
       if (now - this.lastPasteTime < 100) return;
       this.lastPasteTime = now;
@@ -1319,24 +1319,33 @@ export class TuiApp {
       }) as ImageContent);
       images = [...(images ?? []), ...atImages];
     }
-    // Resolve fileRefs from tracker (drag-and-drop files) with @path dedup
+    // Split fileRefs by type: images vs non-images
     if (hasFiles) {
-      const dedupedFileRefs = fileRefs.filter(f => !atPathAbsPaths.has(f));
-      if (dedupedFileRefs.length > 0) {
-        const refsResolved = resolveFileRefs(this.deps.config.projectPath, dedupedFileRefs, this.deps.config.atFile ?? {});
-        if (refsResolved.warnings.length > 0) {
-          for (const warn of refsResolved.warnings) {
-            this.conversation.addInfo(c.yellow(`${warn.path ?? ""}: ${warn.type}${warn.detail ? ` — ${warn.detail}` : ""}`));
+      const imageRefs = fileRefs.filter(f => isImagePath(f));
+      const nonImageRefs = fileRefs.filter(f => !isImagePath(f));
+      // Non-image files: inject path references only
+      if (nonImageRefs.length > 0) {
+        const pathLines = nonImageRefs.map(f => `- \`${f}\``).join('\n');
+        text = text ? `${text}\n\n📁 Attached files:\n${pathLines}` : `📁 Attached files:\n${pathLines}`;
+      }
+      // Image files: resolve with @path dedup
+      if (imageRefs.length > 0) {
+        const dedupedImageRefs = imageRefs.filter(f => !atPathAbsPaths.has(f));
+        if (dedupedImageRefs.length > 0) {
+          const refsResolved = resolveFileRefs(this.deps.config.projectPath, dedupedImageRefs, this.deps.config.atFile ?? {});
+          if (refsResolved.warnings.length > 0) {
+            for (const warn of refsResolved.warnings) {
+              this.conversation.addInfo(c.yellow(`${warn.path ?? ""}: ${warn.type}${warn.detail ? ` — ${warn.detail}` : ""}`));
+            }
           }
-        }
-        text = text ? `${text}\n${refsResolved.text}` : refsResolved.text;
-        if (refsResolved.images.length > 0) {
-          const refImages: ImageContent[] = refsResolved.images.map((img) => ({
-            type: "image" as const,
-            data: img.data,
-            mimeType: img.mimeType,
-          }) as ImageContent);
-          images = [...(images ?? []), ...refImages];
+          if (refsResolved.images.length > 0) {
+            const refImages: ImageContent[] = refsResolved.images.map((img) => ({
+              type: "image" as const,
+              data: img.data,
+              mimeType: img.mimeType,
+            }) as ImageContent);
+            images = [...(images ?? []), ...refImages];
+          }
         }
       }
     }

--- a/src/ui/tui-app.ts
+++ b/src/ui/tui-app.ts
@@ -180,6 +180,8 @@ export class TuiApp {
   private attachmentScrollOffset: number = 0;
   // Pre-drained images: captured in input listener before Editor's onChange("") clears them
   private drainedSubmitImages: ImageContent[] | null = null;
+  // Pre-drained files: captured in input listener before Editor's onChange("") clears them
+  private drainedSubmitFiles: string[] | null = null;
   private lastPasteTime = 0;
   // ── Kitty protocol multi-chunk buffer ──
   // Kitty transmits large images in chunks. Accumulate base64 payloads here
@@ -271,11 +273,16 @@ export class TuiApp {
       if (pasteResult) {
         return pasteResult;
       }
-      // Pre-submit drain: if Enter/Return is pressed with pending images,
+      // Pre-submit drain: if Enter/Return is pressed with pending images or files,
       // drain them NOW before the Editor fires onChange("") which would
-      // otherwise trigger removeImageById.
-      if ((matchesKey(data, Key.enter) || matchesKey(data, Key.return) || data === "\r" || data === "\n") && this.imagePasteHandler.imageCount > 0 && !this.processing) {
-        this.drainedSubmitImages = this.imagePasteHandler.drainImages();
+      // otherwise trigger removeImageById / fileTracker.remove.
+      if ((matchesKey(data, Key.enter) || matchesKey(data, Key.return) || data === "\r" || data === "\n") && !this.processing) {
+        if (this.imagePasteHandler.imageCount > 0) {
+          this.drainedSubmitImages = this.imagePasteHandler.drainImages();
+        }
+        if (this.fileTracker.count > 0) {
+          this.drainedSubmitFiles = this.fileTracker.drain();
+        }
       }
       if (this.handleInput(data)) {
         return { consume: true };
@@ -1203,7 +1210,8 @@ export class TuiApp {
     }
     const hasText = text.length > 0;
     const hasImages = Boolean(images?.length);
-    const fileRefs = this.fileTracker.drain();
+    const fileRefs = this.drainedSubmitFiles ?? this.fileTracker.drain();
+    this.drainedSubmitFiles = null;
     const hasFiles = fileRefs.length > 0;
     if (!hasText && !hasImages && !hasFiles) {
       const now = Date.now();

--- a/src/ui/web/web-backend.ts
+++ b/src/ui/web/web-backend.ts
@@ -1,6 +1,6 @@
 import { createServer, request as httpRequest } from "node:http";
 import type { IncomingMessage, ServerResponse } from "node:http";
-import { readFileSync, existsSync } from "node:fs";
+import { readFileSync, existsSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { join, extname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { ImageContent } from "@earendil-works/pi-ai";
@@ -98,6 +98,17 @@ export class WebUiBackend implements UiBackend {
   private contextWindowThrottlePending: boolean = false;
   private lastArtifactHtml: string = "";
   private isAssistantTurn: boolean = false;
+
+  private cleanupUploadDir(sessionId: string): void {
+    const uploadDir = join(this.config.projectPath, ".dscode", "uploads", sessionId);
+    if (existsSync(uploadDir)) {
+      try {
+        rmSync(uploadDir, { recursive: true, force: true });
+      } catch {
+        // Ignore cleanup errors
+      }
+    }
+  }
 
   constructor(options: WebUiOptions) {
     this.port = options.port;
@@ -504,6 +515,55 @@ export class WebUiBackend implements UiBackend {
         for (const warn of resolved.warnings) {
           client.send({ type: "info", display: "toast", text: `@${warn.path ?? ""}: ${warn.type}${warn.detail ? ` — ${warn.detail}` : ""}` });
         }
+        // Handle uploaded files from web drag-and-drop (browser-read content → temp files)
+        if (cmd.uploadedFiles && cmd.uploadedFiles.length > 0) {
+          const sm = this.harness.sessionManager;
+          const sessionId = sm.getCurrentSessionId?.() ?? "default";
+          const ts = Date.now();
+          const uploadDir = join(this.config.projectPath, ".dscode", "uploads", sessionId);
+          mkdirSync(uploadDir, { recursive: true });
+          const tempPaths: string[] = [];
+          for (const uf of cmd.uploadedFiles) {
+            const tempName = `${ts}-${uf.name}`;
+            const tempPath = join(uploadDir, tempName);
+            writeFileSync(tempPath, uf.content, "utf-8");
+            tempPaths.push(tempPath);
+          }
+          if (tempPaths.length > 0) {
+            const pathLines = tempPaths.map(p => `- \`${p}\``).join('\n');
+            text = text ? `${text}\n\n📁 Attached files:\n${pathLines}` : `📁 Attached files:\n${pathLines}`;
+          }
+        }
+
+        // Handle fileRefs (TUI drag-and-drop: absolute filesystem paths)
+        if (cmd.fileRefs && cmd.fileRefs.length > 0) {
+          const imageRefs = cmd.fileRefs.filter(f => isImagePath(f));
+          const nonImageRefs = cmd.fileRefs.filter(f => !isImagePath(f));
+          // Non-image files from TUI: inject path references only (files exist on filesystem)
+          if (nonImageRefs.length > 0) {
+            const pathLines = nonImageRefs.map(f => `- \`${f}\``).join('\n');
+            text = text ? `${text}\n\n📁 Attached files:\n${pathLines}` : `📁 Attached files:\n${pathLines}`;
+          }
+          // Image files from TUI: resolve normally from filesystem
+          if (imageRefs.length > 0) {
+            const refsResolved = resolveFileRefs(this.config.projectPath, imageRefs, this.config.atFile ?? {});
+            if (!refsResolved.reject) {
+              if (refsResolved.text) {
+                text = text ? `${text}\n\n${refsResolved.text}` : refsResolved.text;
+              }
+              if (refsResolved.images.length > 0) {
+                const refImages = refsResolved.images.map((img) => ({
+                  data: img.data,
+                  mimeType: img.mimeType,
+                }));
+                images = [...(images ?? []), ...refImages];
+              }
+            }
+            for (const warn of refsResolved.warnings) {
+              client.send({ type: "info", display: "toast", text: `${warn.path ?? ""}: ${warn.type}${warn.detail ? ` — ${warn.detail}` : ""}` });
+            }
+          }
+        }
         // Split fileRefs by type: images vs non-images
         if (cmd.fileRefs && cmd.fileRefs.length > 0) {
           const imageRefs = cmd.fileRefs.filter(f => isImagePath(f));
@@ -545,6 +605,7 @@ export class WebUiBackend implements UiBackend {
               mimeType: img.mimeType,
             }) as ImageContent);
             this.pendingImages = [];
+            this.harness.logger.info("tool", "web-backend", `promptWithImages: textLen=${text.length}, images=${imageContents.length}, img[0].dataLen=${imageContents[0]?.data?.length ?? 0}, mime=${imageContents[0]?.mimeType ?? "?"}`);
             await this.harness.promptWithImages(text, imageContents);
           } else {
             this.pendingImages = [];
@@ -1128,6 +1189,7 @@ export class WebUiBackend implements UiBackend {
         }
         if (wasCurrent) {
           client.send({ type: "clear_conversation" });
+          this.cleanupUploadDir(cmd.id);
         }
         client.send({ type: "info", display: "toast", text: "Session deleted." });
         const sessions = sessionManager.listSessions();

--- a/src/ui/web/web-backend.ts
+++ b/src/ui/web/web-backend.ts
@@ -260,22 +260,6 @@ export class WebUiBackend implements UiBackend {
     this.broadcast({ type: "tool_start", name, args });
   }
 
-  toolEnd(name: string, result: unknown, isError: boolean): void {
-    const resultStr = typeof result === "string" ? result.slice(0, 5000) : JSON.stringify(result).slice(0, 5000);
-    const images = extractImagesFromToolResult(result);
-    if (this.currentAssistant) {
-      this.currentAssistant.tools = this.currentAssistant.tools.filter((t) => t.name !== name || t.result !== "");
-      this.currentAssistant.tools.push({
-        name,
-        args: "",
-        result: resultStr,
-        isError,
-        images,
-      });
-    }
-    this.broadcast({ type: "tool_end", name, result: resultStr, isError, images });
-    this.broadcastContextWindow(false);
-  }
   finishAssistantMessage(): void {
     this.broadcastSessionTime();
     this.stopSessionTimeBroadcast();

--- a/src/ui/web/web-backend.ts
+++ b/src/ui/web/web-backend.ts
@@ -20,7 +20,7 @@ import type { MCPManager } from "../../mcp/manager.js";
 import type { AppHostManager } from "../../mcp/app/host.js";
 import type { AppInstance } from "../../mcp/app/types.js";
 import { buildMcpServers } from "../mcp-browser.js";
-import { resolveAtFileRefs, resolveFileRefs, listProjectFiles } from "../../utils/at-file-resolver.js";
+import { resolveAtFileRefs, resolveFileRefs, listProjectFiles, isImagePath } from "../../utils/at-file-resolver.js";
 import { rebuildDisplayMessages } from "../../session/display.js";
 import { formatToolResultForUI } from "../shared/tool-result-formatter.js";
 import { WsServer, type WebSocketClient } from "./ws-server.js";
@@ -504,23 +504,33 @@ export class WebUiBackend implements UiBackend {
         for (const warn of resolved.warnings) {
           client.send({ type: "info", display: "toast", text: `@${warn.path ?? ""}: ${warn.type}${warn.detail ? ` — ${warn.detail}` : ""}` });
         }
-        // Resolve fileRefs from drag-and-drop tracker
+        // Split fileRefs by type: images vs non-images
         if (cmd.fileRefs && cmd.fileRefs.length > 0) {
-          const refsResolved = resolveFileRefs(this.config.projectPath, cmd.fileRefs, this.config.atFile ?? {});
-          if (!refsResolved.reject) {
-            if (refsResolved.text) {
-              text = text ? `${text}\n\n${refsResolved.text}` : refsResolved.text;
-            }
-            if (refsResolved.images.length > 0) {
-              const refImages = refsResolved.images.map((img) => ({
-                data: img.data,
-                mimeType: img.mimeType,
-              }));
-              images = [...(images ?? []), ...refImages];
-            }
+          const imageRefs = cmd.fileRefs.filter(f => isImagePath(f));
+          const nonImageRefs = cmd.fileRefs.filter(f => !isImagePath(f));
+          // Non-image files: inject path references only
+          if (nonImageRefs.length > 0) {
+            const pathLines = nonImageRefs.map(f => `- \`${f}\``).join('\n');
+            text = text ? `${text}\n\n📁 Attached files:\n${pathLines}` : `📁 Attached files:\n${pathLines}`;
           }
-          for (const warn of refsResolved.warnings) {
-            client.send({ type: "info", display: "toast", text: `${warn.path ?? ""}: ${warn.type}${warn.detail ? ` — ${warn.detail}` : ""}` });
+          // Image files: resolve normally
+          if (imageRefs.length > 0) {
+            const refsResolved = resolveFileRefs(this.config.projectPath, imageRefs, this.config.atFile ?? {});
+            if (!refsResolved.reject) {
+              if (refsResolved.text) {
+                text = text ? `${text}\n\n${refsResolved.text}` : refsResolved.text;
+              }
+              if (refsResolved.images.length > 0) {
+                const refImages = refsResolved.images.map((img) => ({
+                  data: img.data,
+                  mimeType: img.mimeType,
+                }));
+                images = [...(images ?? []), ...refImages];
+              }
+            }
+            for (const warn of refsResolved.warnings) {
+              client.send({ type: "info", display: "toast", text: `${warn.path ?? ""}: ${warn.type}${warn.detail ? ` — ${warn.detail}` : ""}` });
+            }
           }
         }
         // Broadcast user message to client before sending to agent

--- a/src/ui/web/web-backend.ts
+++ b/src/ui/web/web-backend.ts
@@ -525,7 +525,7 @@ export class WebUiBackend implements UiBackend {
           for (const uf of cmd.uploadedFiles) {
             const tempName = `${ts}-${uf.name}`;
             const tempPath = join(uploadDir, tempName);
-            writeFileSync(tempPath, uf.content, "utf-8");
+            writeFileSync(tempPath, Buffer.from(uf.content, "base64"));
             tempPaths.push(tempPath);
           }
           if (tempPaths.length > 0) {

--- a/src/ui/web/web-backend.ts
+++ b/src/ui/web/web-backend.ts
@@ -1,6 +1,6 @@
 import { createServer, request as httpRequest } from "node:http";
 import type { IncomingMessage, ServerResponse } from "node:http";
-import { readFileSync, existsSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { readFileSync, existsSync, mkdirSync, writeFileSync, rmSync, readdirSync, statSync } from "node:fs";
 import { join, extname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { ImageContent } from "@earendil-works/pi-ai";
@@ -58,7 +58,6 @@ export interface WebUiOptions {
 }
 
 /**
- * Web UI backend that implements UiBackend.
  * Creates an HTTP server + WebSocket server, serves the SPA,
  * and translates all UI callbacks into WebSocket events.
  */
@@ -765,11 +764,60 @@ export class WebUiBackend implements UiBackend {
         await this.handleArtifact(client, cmd as ClientCommand & { type: "artifact"; action: "generate" | "update"; context?: string; instruction?: string });
         break;
       }
+      case "cache": {
+        this.handleCache(client, cmd as ClientCommand & { type: "cache"; action: "size" | "clear" });
+        break;
+      }
       case "mcp": {
         this.handleMcp(client, cmd);
         break;
       }
     }
+  }
+
+  private handleCache(client: WebSocketClient, cmd: ClientCommand & { type: "cache"; action: "size" | "clear" }): void {
+    const uploadsDir = join(this.config.projectPath, ".dscode", "uploads");
+
+    if (cmd.action === "clear") {
+      if (existsSync(uploadsDir)) {
+        try {
+          rmSync(uploadsDir, { recursive: true, force: true });
+        } catch {
+          // Ignore cleanup errors
+        }
+      }
+      client.send({ type: "cache_size", totalBytes: 0, fileCount: 0, sessionCount: 0 });
+      return;
+    }
+
+    // action === "size"
+    let totalBytes = 0;
+    let fileCount = 0;
+    let sessionCount = 0;
+
+    if (existsSync(uploadsDir)) {
+      const sessionDirs = readdirSync(uploadsDir, { withFileTypes: true })
+        .filter((d) => d.isDirectory());
+      sessionCount = sessionDirs.length;
+
+      for (const dir of sessionDirs) {
+        const sessionPath = join(uploadsDir, dir.name);
+        const files = readdirSync(sessionPath, { withFileTypes: true });
+        for (const f of files) {
+          if (f.isFile()) {
+            try {
+              const st = statSync(join(sessionPath, f.name));
+              totalBytes += st.size;
+              fileCount++;
+            } catch {
+              // skip
+            }
+          }
+        }
+      }
+    }
+
+    client.send({ type: "cache_size", totalBytes, fileCount, sessionCount });
   }
 
   private async handleSlashCommand(client: WebSocketClient, text: string): Promise<void> {
@@ -1189,8 +1237,8 @@ export class WebUiBackend implements UiBackend {
         }
         if (wasCurrent) {
           client.send({ type: "clear_conversation" });
-          this.cleanupUploadDir(cmd.id);
         }
+        this.cleanupUploadDir(cmd.id);
         client.send({ type: "info", display: "toast", text: "Session deleted." });
         const sessions = sessionManager.listSessions();
         const currentId = sessionManager.getCurrentSessionId?.() ?? undefined;

--- a/src/utils/at-file-resolver.ts
+++ b/src/utils/at-file-resolver.ts
@@ -134,7 +134,7 @@ function isTextPath(filePath: string): boolean {
   return false;
 }
 
-function isImagePath(filePath: string): boolean {
+export function isImagePath(filePath: string): boolean {
   const ext = filePath.slice(filePath.lastIndexOf(".")).toLowerCase();
   return IMAGE_EXTENSIONS.has(ext);
 }

--- a/web/src/components/App.tsx
+++ b/web/src/components/App.tsx
@@ -79,6 +79,9 @@ export function App() {
   const [viewMode, setViewMode] = useState<"chat" | "dashboard">("chat");
   const [artifactHtml, setArtifactHtml] = useState("");
   const [artifactLoading, setArtifactLoading] = useState(false);
+  const [cacheSize, setCacheSize] = useState<{ totalBytes: number; fileCount: number; sessionCount: number } | null>(null);
+  const [cacheClearing, setCacheClearing] = useState(false);
+
   const [transitionPhase, setTransitionPhase] = useState<"idle" | "animating">("idle");
   const { toasts, addToast, removeToast } = useToasts();
   const turnStartRef = useRef<number>(0);
@@ -198,6 +201,10 @@ export function App() {
         }
         break;
       }
+      case "cache_size":
+        setCacheSize({ totalBytes: event.totalBytes, fileCount: event.fileCount, sessionCount: event.sessionCount });
+        setCacheClearing(false);
+        break;
     }
   }, [addToast, sessions]);
 
@@ -230,6 +237,11 @@ export function App() {
   const handleSlashCommand = useCallback((command: string) => send({ type: "slash", command }), [send]);
   const handleCommand = useCallback((cmd: { type: "file_list"; prefix: string }) => send(cmd as any), [send]);
   const handleConfigChange = useCallback((action: string, value: string) => send({ type: "config", action: action as any, value }), [send]);
+
+  const handleCacheAction = useCallback((action: "size" | "clear") => {
+    if (action === "clear") setCacheClearing(true);
+    send({ type: "cache", action } as any);
+  }, [send]);
   const handleSessionAction = useCallback((action: "list" | "save" | "load" | "delete", id?: string) => send({ type: "session", action, id }), [send]);
   const handleMcpAction = useCallback((action: "list" | "refresh" | "connect" | "disconnect", serverName?: string) => send({ type: "mcp", action, serverName } as any), [send]);
   const handleNewSession = useCallback(() => send({ type: "slash", command: "/reset" }), [send]);
@@ -314,7 +326,8 @@ export function App() {
         <Sidebar open={sidebarOpen} onClose={() => setSidebarOpen(false)} activeTab={sidebarTab} onTabChange={setSidebarTab}
           sessions={sessions} currentSessionId={currentSessionId} mcpServers={mcpServers} config={config}
           onSessionAction={handleSessionAction} onMcpAction={handleMcpAction} onMcpServerAction={handleMcpAction}
-          onConfigChange={handleConfigChange} isProcessing={processing} onNewSession={handleNewSession} />
+          onConfigChange={handleConfigChange} isProcessing={processing} onNewSession={handleNewSession}
+          onCacheAction={handleCacheAction} cacheSize={cacheSize} cacheClearing={cacheClearing} />
         <main className="flex-1 flex flex-col min-w-0">
           <div className="flex-1 flex flex-col min-h-0" style={{ position: "relative" }}>
           {transitionPhase === "animating" && (
@@ -326,7 +339,8 @@ export function App() {
             <ChatView messages={messages} processing={processing} hasStreaming={hasStreaming} sessionActiveMs={sessionActiveMs} permissionPrompt={permissionPrompt} onPermission={handlePermission} containerRef={chatContainerRef} scrollLocked={transitionPhase === "animating"} />
           )}
           <MessageInput onSend={handleSend} onAbort={handleAbort} onSlashCommand={handleSlashCommand} onCommand={handleCommand}
-            processing={processing} slashCommands={SLASH_COMMANDS} fileListItems={fileListItems} fileListPrefix={fileListPrefix} viewMode={viewMode} projectPath={config?.projectPath ?? ""} />
+            processing={processing} slashCommands={SLASH_COMMANDS} fileListItems={fileListItems} fileListPrefix={fileListPrefix} viewMode={viewMode} projectPath={config?.projectPath ?? ""}
+            onToast={(type, text) => addToast({ type, text })} />
           </div>
         </main>
       </div>

--- a/web/src/components/App.tsx
+++ b/web/src/components/App.tsx
@@ -203,14 +203,14 @@ export function App() {
 
   const { connected, send } = useWebSocket(handleEvent);
 
-  const handleSend = useCallback((text: string, images?: ImageAttachment[], fileRefs?: string[]) => {
-    if (!text.trim() && (!images || images.length === 0)) return;
+  const handleSend = useCallback((text: string, images?: ImageAttachment[], fileRefs?: string[], uploadedFiles?: { name: string; content: string }[]) => {
+    if (!text.trim() && (!images || images.length === 0) && (!uploadedFiles || uploadedFiles.length === 0)) return;
     turnStartRef.current = Date.now();
     setProcessing(true);
     if (viewMode === "dashboard") {
       send({ type: "artifact", action: "update", instruction: text });
     } else {
-      send({ type: "chat", text, images: images?.length ? images : undefined, fileRefs: fileRefs?.length ? fileRefs : undefined });
+      send({ type: "chat", text, images: images?.length ? images : undefined, fileRefs: fileRefs?.length ? fileRefs : undefined, uploadedFiles: uploadedFiles?.length ? uploadedFiles : undefined });
     }
   }, [send, viewMode]);
 

--- a/web/src/components/ChatView.tsx
+++ b/web/src/components/ChatView.tsx
@@ -366,7 +366,7 @@ function UserBubble({ message }: { message: UIMessage }) {
 
   return (
     <div className="user-msg">
-      <div className="meta">You · 09:41</div>
+      <div className="meta">You{message.createdAt ? ` · ${new Date(message.createdAt).toLocaleTimeString()}` : ""}</div>
       <div data-collider="message-card" className="content">
         {message.images && message.images.length > 0 && (
           <div className="flex flex-wrap gap-2 mb-2 justify-end">
@@ -409,7 +409,7 @@ function AssistantMessage({ message, sessionTime }: { message: UIMessage; sessio
 
   return (
     <div className="assistant-msg">
-      <div className="meta">dscode · 09:41</div>
+      <div className="meta">dscode{message.createdAt ? ` · ${new Date(message.createdAt).toLocaleTimeString()}` : ""}</div>
 
       {message.thinking && (
         <ThinkingBlock thinking={message.thinking} isStreaming={message.isStreaming} sessionTime={sessionTime} />

--- a/web/src/components/Markdown.tsx
+++ b/web/src/components/Markdown.tsx
@@ -24,7 +24,7 @@ export function Markdown({ children, className = "" }: MarkdownProps) {
               : children;
             return (
               <pre
-                className="p-3 overflow-x-auto text-xs my-2"
+                className="p-3 overflow-x-auto text-xs my-1"
                 style={{
                   borderRadius: "8px",
                   backgroundColor: "var(--color-bg)",

--- a/web/src/components/Markdown.tsx
+++ b/web/src/components/Markdown.tsx
@@ -24,13 +24,7 @@ export function Markdown({ children, className = "" }: MarkdownProps) {
               : children;
             return (
               <pre
-                className="p-3 overflow-x-auto text-xs my-1"
-                style={{
-                  borderRadius: "8px",
-                  backgroundColor: "var(--color-bg)",
-                  border: "1px solid var(--color-border)",
-                  color: "var(--color-text)",
-                }}
+                className="md-pre-base p-3 overflow-x-auto text-xs my-1"
               >
                 {wrappedChildren}
               </pre>

--- a/web/src/components/MessageInput.tsx
+++ b/web/src/components/MessageInput.tsx
@@ -12,6 +12,7 @@ interface MessageInputProps {
   fileListItems: FileListItem[];
   fileListPrefix: string;
   projectPath: string;
+  onToast?: (type: "warning" | "error", text: string) => void;
   viewMode?: "chat" | "dashboard";
 }
 
@@ -100,8 +101,8 @@ function formatFileSize(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
-const MAX_FILE_SIZE = 50 * 1024; // 50KB
-const MAX_TOTAL_SIZE = 200 * 1024; // 200KB
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
+const MAX_TOTAL_SIZE = 50 * 1024 * 1024; // 50 MB
 
 export function MessageInput({
   onSend,
@@ -114,6 +115,7 @@ export function MessageInput({
   fileListPrefix,
   viewMode,
   projectPath,
+  onToast,
 }: MessageInputProps) {
   const [text, setText] = useState("");
   const [images, setImages] = useState<ImageAttachment[]>([]);
@@ -471,8 +473,13 @@ export function MessageInput({
         }
       } else {
         // Non-image: read as text, upload to server as temp file
-        if (file.size > MAX_FILE_SIZE || totalSize + file.size > MAX_TOTAL_SIZE) {
-          continue; // skip oversized
+        if (file.size > MAX_FILE_SIZE) {
+          onToast?.("warning", `File '${file.name}' exceeds 10 MB limit`);
+          continue;
+        }
+        if (totalSize + file.size > MAX_TOTAL_SIZE) {
+          onToast?.("warning", "Total file size exceeds 50 MB limit");
+          continue;
         }
         try {
           const content = await new Promise<string>((resolve, reject) => {

--- a/web/src/components/MessageInput.tsx
+++ b/web/src/components/MessageInput.tsx
@@ -472,7 +472,7 @@ export function MessageInput({
           // skip
         }
       } else {
-        // Non-image: read as text, upload to server as temp file
+        // Non-image: read as base64, upload to server as temp file
         if (file.size > MAX_FILE_SIZE) {
           onToast?.("warning", `File '${file.name}' exceeds 10 MB limit`);
           continue;
@@ -484,9 +484,13 @@ export function MessageInput({
         try {
           const content = await new Promise<string>((resolve, reject) => {
             const reader = new FileReader();
-            reader.onload = () => resolve(reader.result as string);
+            reader.onload = () => {
+              const dataUrl = reader.result as string;
+              // Strip "data:<mime>;base64," prefix, keep raw base64
+              resolve(dataUrl.substring(dataUrl.indexOf(',') + 1));
+            };
             reader.onerror = reject;
-            reader.readAsText(file);
+            reader.readAsDataURL(file);
           });
           newUploads.push({ name: file.name, size: file.size, content });
           totalSize += file.size;

--- a/web/src/components/MessageInput.tsx
+++ b/web/src/components/MessageInput.tsx
@@ -1,10 +1,9 @@
 import { useState, useRef, useCallback, useEffect } from "react";
 import type { ImageAttachment, FileAttachment, FileListItem } from "../types";
-import { FileTracker } from "@dscode/shared/file-tracker";
 import { PaperPlaneTilt, Folder, File, Image, TextAlignLeft, Video, SpeakerHigh, FilePdf, Archive, X } from "@phosphor-icons/react";
 
 interface MessageInputProps {
-  onSend: (text: string, images?: ImageAttachment[], fileRefs?: string[]) => void;
+  onSend: (text: string, images?: ImageAttachment[], fileRefs?: string[], uploadedFiles?: { name: string; content: string }[]) => void;
   onAbort: () => void;
   onSlashCommand: (command: string) => void;
   onCommand: (cmd: { type: "file_list"; prefix: string }) => void;
@@ -19,15 +18,43 @@ interface MessageInputProps {
 function fileToImageAttachment(file: File): Promise<ImageAttachment> {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
-    reader.onload = () => {
+    reader.onload = async () => {
       const dataUrl = reader.result as string;
-      const commaIdx = dataUrl.indexOf(",");
-      const mimeType = dataUrl.slice(5, dataUrl.indexOf(";"));
-      const data = dataUrl.slice(commaIdx + 1);
+      const compressed = await compressImage(dataUrl);
+      const commaIdx = compressed.indexOf(",");
+      const mimeType = compressed.slice(5, compressed.indexOf(";"));
+      const data = compressed.slice(commaIdx + 1);
       resolve({ data, mimeType });
     };
     reader.onerror = reject;
     reader.readAsDataURL(file);
+  });
+}
+
+function compressImage(dataUrl: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const img = new window.Image();
+    img.onload = () => {
+      const MAX_HEIGHT = 480;
+      if (img.height <= MAX_HEIGHT) {
+        resolve(dataUrl);
+        return;
+      }
+      const scale = MAX_HEIGHT / img.height;
+      const width = Math.round(img.width * scale);
+      const canvas = document.createElement("canvas");
+      canvas.width = width;
+      canvas.height = MAX_HEIGHT;
+      const ctx = canvas.getContext("2d");
+      if (!ctx) {
+        resolve(dataUrl);
+        return;
+      }
+      ctx.drawImage(img, 0, 0, width, MAX_HEIGHT);
+      resolve(canvas.toDataURL("image/jpeg", 0.85));
+    };
+    img.onerror = () => reject(new Error("Failed to load image for compression"));
+    img.src = dataUrl;
   });
 }
 
@@ -73,6 +100,8 @@ function formatFileSize(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
+const MAX_FILE_SIZE = 50 * 1024; // 50KB
+const MAX_TOTAL_SIZE = 200 * 1024; // 200KB
 
 export function MessageInput({
   onSend,
@@ -88,7 +117,7 @@ export function MessageInput({
 }: MessageInputProps) {
   const [text, setText] = useState("");
   const [images, setImages] = useState<ImageAttachment[]>([]);
-  const [files, setFiles] = useState<{ absPath: string; displayPath: string }[]>([]);
+  const [uploadedFiles, setUploadedFiles] = useState<{ name: string; size: number; content: string }[]>([]);
   const [isDragOver, setIsDragOver] = useState(false);
   const [showSlashMenu, setShowSlashMenu] = useState(false);
   const [slashFilter, setSlashFilter] = useState("");
@@ -101,7 +130,6 @@ export function MessageInput({
   const historyCursorRef = useRef<number>(-1);
   const draftRef = useRef<string>("");
   const isComposingRef = useRef(false);
-  const trackerRef = useRef<FileTracker>(new FileTracker());
   const MAX_HISTORY = 100;
 
   const filteredCommands = slashCommands.filter(
@@ -125,8 +153,7 @@ export function MessageInput({
 
   const handleSubmit = useCallback(() => {
     const trimmed = text.trim();
-    const fileRefs = trackerRef.current.drain();
-    if (!trimmed && images.length === 0 && fileRefs.length === 0) return;
+    if (!trimmed && images.length === 0 && uploadedFiles.length === 0) return;
     // Push to history if non-empty and not duplicate of last entry
     if (trimmed && historyRef.current[0] !== trimmed) {
       historyRef.current.unshift(trimmed);
@@ -135,13 +162,16 @@ export function MessageInput({
       }
     }
     historyCursorRef.current = -1;
-    onSend(trimmed, images.length > 0 ? images : undefined, fileRefs.length > 0 ? fileRefs : undefined);
+    const uploadPayload = uploadedFiles.length > 0
+      ? uploadedFiles.map(f => ({ name: f.name, content: f.content }))
+      : undefined;
+    onSend(trimmed, images.length > 0 ? images : undefined, undefined, uploadPayload);
     setText("");
     setImages([]);
-    setFiles([]);
+    setUploadedFiles([]);
     setShowSlashMenu(false);
     setShowFileMenu(false);
-  }, [text, images, onSend]);
+  }, [text, images, uploadedFiles, onSend]);
 
   const navigateToDirectory = (dirPath: string) => {
     const textarea = textareaRef.current;
@@ -401,9 +431,8 @@ export function MessageInput({
     setImages((prev) => prev.filter((_, i) => i !== index));
   }, []);
 
-  const removeFile = useCallback((absPath: string) => {
-    trackerRef.current.remove(absPath);
-    setFiles((prev) => prev.filter((f) => f.absPath !== absPath));
+  const removeUploadedFile = useCallback((index: number) => {
+    setUploadedFiles((prev) => prev.filter((_, i) => i !== index));
   }, []);
 
   const handleDragOver = useCallback((e: React.DragEvent) => {
@@ -417,7 +446,7 @@ export function MessageInput({
     setIsDragOver(false);
   }, []);
 
-  const handleDrop = useCallback((e: React.DragEvent) => {
+  const handleDrop = useCallback(async (e: React.DragEvent) => {
     if (processing) return;
     e.preventDefault();
     setIsDragOver(false);
@@ -425,22 +454,52 @@ export function MessageInput({
     const droppedFiles = e.dataTransfer.files;
     if (droppedFiles.length === 0) return;
 
-    const tracker = trackerRef.current;
-    const newEntries: { absPath: string; displayPath: string }[] = [];
+    const newImages: ImageAttachment[] = [];
+    const newUploads: { name: string; size: number; content: string }[] = [];
+    let totalSize = 0;
 
     for (let i = 0; i < droppedFiles.length; i++) {
       const file = droppedFiles[i];
-      const absPath = (file as any).path ?? file.name;
-      const displayPath = tracker.add(absPath, projectPath);
-      newEntries.push({ absPath, displayPath });
+
+      if (file.type.startsWith("image/")) {
+        // Image: read as base64, same as paste
+        try {
+          const img = await fileToImageAttachment(file);
+          newImages.push(img);
+        } catch {
+          // skip
+        }
+      } else {
+        // Non-image: read as text, upload to server as temp file
+        if (file.size > MAX_FILE_SIZE || totalSize + file.size > MAX_TOTAL_SIZE) {
+          continue; // skip oversized
+        }
+        try {
+          const content = await new Promise<string>((resolve, reject) => {
+            const reader = new FileReader();
+            reader.onload = () => resolve(reader.result as string);
+            reader.onerror = reject;
+            reader.readAsText(file);
+          });
+          newUploads.push({ name: file.name, size: file.size, content });
+          totalSize += file.size;
+        } catch {
+          // skip
+        }
+      }
     }
 
-    setFiles((prev) => [...prev, ...newEntries]);
+    if (newImages.length > 0) {
+      setImages((prev) => [...prev, ...newImages]);
+    }
+    if (newUploads.length > 0) {
+      setUploadedFiles((prev) => [...prev, ...newUploads]);
+    }
 
     requestAnimationFrame(() => {
       textareaRef.current?.focus();
     });
-  }, [processing, projectPath]);
+  }, [processing]);
 
   const adjustHeight = () => {
     const ta = textareaRef.current;
@@ -580,14 +639,14 @@ export function MessageInput({
         </div>
       )}
 
-      {/* File chips */}
-      {files.length > 0 && (
+      {/* Uploaded file chips */}
+      {uploadedFiles.length > 0 && (
         <div className="flex flex-wrap gap-2 mb-2 max-w-4xl mx-auto">
-          {files.map((f) => {
-            const IconComponent = getFileIconFromPath(f.displayPath);
+          {uploadedFiles.map((f, i) => {
+            const IconComponent = getFileIconFromPath(f.name);
             return (
               <div
-                key={f.absPath}
+                key={`${f.name}-${i}`}
                 className="flex items-center gap-1.5 px-2.5 py-1.5 text-sm max-w-[200px]"
                 style={{
                   border: "1px solid var(--color-border)",
@@ -599,12 +658,12 @@ export function MessageInput({
                 <span
                   className="truncate text-xs"
                   style={{ color: "var(--color-text)" }}
-                  title={f.displayPath}
+                  title={f.name}
                 >
-                  {f.displayPath}
+                  {f.name}
                 </span>
                 <button
-                  onClick={() => removeFile(f.absPath)}
+                  onClick={() => removeUploadedFile(i)}
                   className="flex-shrink-0 w-4 h-4 rounded text-xs flex items-center justify-center ml-0.5"
                   style={{ color: "var(--color-text-muted)" }}
                   title="Remove file"
@@ -685,7 +744,7 @@ export function MessageInput({
         ) : (
           <button
             onClick={handleSubmit}
-            disabled={!text.trim() && images.length === 0 && files.length === 0}
+            disabled={!text.trim() && images.length === 0 && uploadedFiles.length === 0}
             className="btn-primary shrink-0"
           >
             <PaperPlaneTilt size={16} weight="bold" />

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -17,7 +17,11 @@ interface SidebarProps {
   onMcpServerAction: (action: "connect" | "disconnect", serverName: string) => void;
   onConfigChange: (action: string, value: string) => void;
   onNewSession: () => void;
-  isProcessing: boolean;}
+  isProcessing: boolean;
+  onCacheAction?: (action: "size" | "clear") => void;
+  cacheSize?: { totalBytes: number; fileCount: number; sessionCount: number } | null;
+  cacheClearing?: boolean;
+}
 
 export function Sidebar({
   open,
@@ -33,7 +37,11 @@ export function Sidebar({
   onConfigChange,
   onNewSession,
   onMcpServerAction,
-  isProcessing,}: SidebarProps) {
+  isProcessing,
+  onCacheAction,
+  cacheSize,
+  cacheClearing,
+}: SidebarProps) {
   const { width, panelRef, handleProps } = useResizablePanel({
     storageKey: "dscode-sidebar-width",
   });
@@ -149,6 +157,9 @@ export function Sidebar({
             <SettingsPanel
               config={config}
               onChange={onConfigChange}
+              onCacheAction={onCacheAction}
+              cacheSize={cacheSize}
+              cacheClearing={cacheClearing}
             />
           )}
         </div>
@@ -403,9 +414,15 @@ function McpPanel({
 function SettingsPanel({
   config,
   onChange,
+  onCacheAction,
+  cacheSize,
+  cacheClearing,
 }: {
   config: ConfigData | null;
   onChange: (action: string, value: string) => void;
+  onCacheAction?: (action: "size" | "clear") => void;
+  cacheSize?: { totalBytes: number; fileCount: number; sessionCount: number } | null;
+  cacheClearing?: boolean;
 }) {
   const [apiKey, setApiKey] = useState("");
   const [modelInput, setModelInput] = useState(config?.modelId ?? "");
@@ -414,6 +431,11 @@ function SettingsPanel({
   const [projectPath, setProjectPath] = useState(config?.projectPath ?? "");
   const [showVisionForm, setShowVisionForm] = useState(false);
   const prevConfigRef = useRef(config);
+
+  // Request cache size on mount
+  useEffect(() => {
+    onCacheAction?.("size");
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     if (config && config !== prevConfigRef.current) {
@@ -567,6 +589,86 @@ function SettingsPanel({
             Set
           </button>
         </div>
+      </div>
+
+      {/* Upload Cache */}
+      <div
+        className="pt-2"
+        style={{ borderTop: "1px solid var(--color-border)" }}
+      >
+        <label
+          className="text-xs mb-1 block"
+          style={{ color: "var(--color-text-muted)" }}
+        >
+          Upload Cache
+        </label>
+        <div
+          className="flex items-center justify-between px-3 py-2"
+          style={{
+            borderRadius: "8px",
+            border: cacheSize != null && cacheSize.totalBytes > 40 * 1024 * 1024
+              ? "1px solid var(--color-error-text)"
+              : "1px solid var(--color-border)",
+            backgroundColor: "var(--color-bg)",
+          }}
+        >
+          <div>
+            <div
+              style={{
+                fontFamily: "'Geist Mono', monospace",
+                fontSize: "16px",
+                fontWeight: 700,
+                color: "var(--color-text)",
+              }}
+            >
+              {cacheSize == null || cacheClearing
+                ? "..."
+                : cacheSize.totalBytes === 0
+                ? "0 B"
+                : cacheSize.totalBytes < 1024
+                ? `${cacheSize.totalBytes} B`
+                : cacheSize.totalBytes < 1024 * 1024
+                ? `${(cacheSize.totalBytes / 1024).toFixed(1)} KB`
+                : `${(cacheSize.totalBytes / (1024 * 1024)).toFixed(1)} MB`}
+            </div>
+            <div
+              className="text-xs"
+              style={{ color: "var(--color-text-muted)" }}
+            >
+              {cacheSize == null || cacheClearing
+                ? "calculating..."
+                : cacheSize.totalBytes === 0
+                ? "no cached files"
+                : `${cacheSize.fileCount} files · ${cacheSize.sessionCount} sessions`}
+            </div>
+          </div>
+          <button
+            onClick={() => onCacheAction?.("clear")}
+            disabled={cacheSize == null || cacheSize.totalBytes === 0 || cacheClearing}
+            className="text-xs px-3 py-1 rounded-btn transition-colors"
+            style={{
+              color: "var(--color-error-text)",
+              opacity: (cacheSize == null || cacheSize.totalBytes === 0 || cacheClearing) ? 0.4 : 1,
+              cursor: (cacheSize == null || cacheSize.totalBytes === 0 || cacheClearing) ? "not-allowed" : "pointer",
+            }}
+          >
+            Clear
+          </button>
+        </div>
+        {cacheSize != null && cacheSize.totalBytes > 40 * 1024 * 1024 && (
+          <p
+            className="text-xs mt-1"
+            style={{ color: "var(--color-error-text)" }}
+          >
+            Consider clearing to free disk space
+          </p>
+        )}
+        <p
+          className="text-xs mt-1"
+          style={{ color: "var(--color-text-muted)" }}
+        >
+          Files in .dscode/uploads/
+        </p>
       </div>
 
       {/* Vision Model Section */}

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -591,85 +591,6 @@ function SettingsPanel({
         </div>
       </div>
 
-      {/* Upload Cache */}
-      <div
-        className="pt-2"
-        style={{ borderTop: "1px solid var(--color-border)" }}
-      >
-        <label
-          className="text-xs mb-1 block"
-          style={{ color: "var(--color-text-muted)" }}
-        >
-          Upload Cache
-        </label>
-        <div
-          className="flex items-center justify-between px-3 py-2"
-          style={{
-            borderRadius: "8px",
-            border: cacheSize != null && cacheSize.totalBytes > 40 * 1024 * 1024
-              ? "1px solid var(--color-error-text)"
-              : "1px solid var(--color-border)",
-            backgroundColor: "var(--color-bg)",
-          }}
-        >
-          <div>
-            <div
-              style={{
-                fontFamily: "'Geist Mono', monospace",
-                fontSize: "16px",
-                fontWeight: 700,
-                color: "var(--color-text)",
-              }}
-            >
-              {cacheSize == null || cacheClearing
-                ? "..."
-                : cacheSize.totalBytes === 0
-                ? "0 B"
-                : cacheSize.totalBytes < 1024
-                ? `${cacheSize.totalBytes} B`
-                : cacheSize.totalBytes < 1024 * 1024
-                ? `${(cacheSize.totalBytes / 1024).toFixed(1)} KB`
-                : `${(cacheSize.totalBytes / (1024 * 1024)).toFixed(1)} MB`}
-            </div>
-            <div
-              className="text-xs"
-              style={{ color: "var(--color-text-muted)" }}
-            >
-              {cacheSize == null || cacheClearing
-                ? "calculating..."
-                : cacheSize.totalBytes === 0
-                ? "no cached files"
-                : `${cacheSize.fileCount} files · ${cacheSize.sessionCount} sessions`}
-            </div>
-          </div>
-          <button
-            onClick={() => onCacheAction?.("clear")}
-            disabled={cacheSize == null || cacheSize.totalBytes === 0 || cacheClearing}
-            className="text-xs px-3 py-1 rounded-btn transition-colors"
-            style={{
-              color: "var(--color-error-text)",
-              opacity: (cacheSize == null || cacheSize.totalBytes === 0 || cacheClearing) ? 0.4 : 1,
-              cursor: (cacheSize == null || cacheSize.totalBytes === 0 || cacheClearing) ? "not-allowed" : "pointer",
-            }}
-          >
-            Clear
-          </button>
-        </div>
-        {cacheSize != null && cacheSize.totalBytes > 40 * 1024 * 1024 && (
-          <p
-            className="text-xs mt-1"
-            style={{ color: "var(--color-error-text)" }}
-          >
-            Consider clearing to free disk space
-          </p>
-        )}
-        <p
-          className="text-xs mt-1"
-          style={{ color: "var(--color-text-muted)" }}
-        >
-          Files in .dscode/uploads/
-        </p>
-      </div>
 
       {/* Vision Model Section */}
       {config.vision != null || showVisionForm ? (
@@ -781,6 +702,86 @@ function SettingsPanel({
           style={{ color: "var(--color-text-muted)" }}
         >
           Max Tokens: {config.maxTokens.toLocaleString()}
+        </p>
+      </div>
+
+      {/* Upload Cache */}
+      <div
+        className="pt-2"
+        style={{ borderTop: "1px solid var(--color-border)" }}
+      >
+        <label
+          className="text-xs mb-1 block"
+          style={{ color: "var(--color-text-muted)" }}
+        >
+          Upload Cache
+        </label>
+        <div
+          className="flex items-center justify-between px-3 py-2"
+          style={{
+            borderRadius: "8px",
+            border: cacheSize != null && cacheSize.totalBytes > 40 * 1024 * 1024
+              ? "1px solid var(--color-error-text)"
+              : "1px solid var(--color-border)",
+            backgroundColor: "var(--color-bg)",
+          }}
+        >
+          <div>
+            <div
+              style={{
+                fontFamily: "'Geist Mono', monospace",
+                fontSize: "16px",
+                fontWeight: 700,
+                color: "var(--color-text)",
+              }}
+            >
+              {cacheSize == null || cacheClearing
+                ? "..."
+                : cacheSize.totalBytes === 0
+                ? "0 B"
+                : cacheSize.totalBytes < 1024
+                ? `${cacheSize.totalBytes} B`
+                : cacheSize.totalBytes < 1024 * 1024
+                ? `${(cacheSize.totalBytes / 1024).toFixed(1)} KB`
+                : `${(cacheSize.totalBytes / (1024 * 1024)).toFixed(1)} MB`}
+            </div>
+            <div
+              className="text-xs"
+              style={{ color: "var(--color-text-muted)" }}
+            >
+              {cacheSize == null || cacheClearing
+                ? "calculating..."
+                : cacheSize.totalBytes === 0
+                ? "no cached files"
+                : `${cacheSize.fileCount} files · ${cacheSize.sessionCount} sessions`}
+            </div>
+          </div>
+          <button
+            onClick={() => onCacheAction?.("clear")}
+            disabled={cacheSize == null || cacheSize.totalBytes === 0 || cacheClearing}
+            className="text-xs px-3 py-1 rounded-btn transition-colors"
+            style={{
+              color: "var(--color-error-text)",
+              opacity: (cacheSize == null || cacheSize.totalBytes === 0 || cacheClearing) ? 0.4 : 1,
+              cursor: (cacheSize == null || cacheSize.totalBytes === 0 || cacheClearing) ? "not-allowed" : "pointer",
+            }}
+          >
+            Clear
+          </button>
+        </div>
+        {cacheSize != null && cacheSize.totalBytes > 40 * 1024 * 1024 && (
+          <p
+            className="text-xs mt-1"
+            style={{ color: "var(--color-error-text)" }}
+          >
+            Consider clearing to free disk space
+          </p>
+        )}
+        <p
+          className="text-xs mt-1"
+          style={{ color: "var(--color-text-muted)" }}
+        >
+          Files in .dscode/uploads/
         </p>
       </div>
     </div>

--- a/web/src/components/ToolCard.tsx
+++ b/web/src/components/ToolCard.tsx
@@ -168,7 +168,6 @@ export function ToolCard({ tool, thinking }: ToolCardProps) {
     ? Math.max(0, Math.min(100, Math.round((tool.progress! / tool.progressTotal!) * 100)))
     : 0;
   const isIndeterminate = hasProgress && !hasProgressTotal;
-  const isCompleted = hasResult && !isError;
 
   // Elapsed time tracking
   const startTimeRef = useRef<number>(Date.now());
@@ -192,12 +191,6 @@ export function ToolCard({ tool, thinking }: ToolCardProps) {
     hadProgressRef.current = hasProgress;
   }, [hasProgress]);
 
-  // Fade-out state: true when progress bar was visible but tool is now done
-  const [progressDone, setProgressDone] = useState(false);
-  if (hasProgress && !hasResult) {
-    if (progressDone) setProgressDone(false);
-  }
-
   const handleHeaderClick = () => {
     if (open) {
       userManuallyCollapsed.current = true;
@@ -215,8 +208,6 @@ export function ToolCard({ tool, thinking }: ToolCardProps) {
     : "\u25CC";
   const statusClass = isError ? "err" : "ok";
   const spinnerClass = hasProgress && !hasResult ? " spinner" : "";
-  const showProgressBar = hasProgress && !isCompleted;
-  const showProgressFadeOut = isCompleted && !progressDone;
 
   const images = useMemo(() => {
     if (tool.images && tool.images.length > 0) {
@@ -304,26 +295,6 @@ export function ToolCard({ tool, thinking }: ToolCardProps) {
                   )}
                 </div>
               </div>
-            )}
-          </div>
-        )}
-
-        {/* Progress bar in expanded body (non-MCP tools + fade-out) */}
-        {!isMcp && (showProgressBar || showProgressFadeOut) && (
-          <div className={`progress-container${showProgressFadeOut ? " progress-fade-out" : ""}`}
-            onTransitionEnd={() => { if (showProgressFadeOut) setProgressDone(true); }}
-          >
-            <div className="progress-bar">
-              <div
-                className={`progress-fill${isIndeterminate ? " indeterminate" : ""}`}
-                style={isIndeterminate ? undefined : { width: `${progressPercent}%` }}
-              />
-            </div>
-            {!isIndeterminate && (
-              <span className="progress-text">{progressPercent}%</span>
-            )}
-            {tool.progressMessage && (
-              <span className="progress-message">{tool.progressMessage}</span>
             )}
           </div>
         )}

--- a/web/src/components/ToolCard.tsx
+++ b/web/src/components/ToolCard.tsx
@@ -344,12 +344,8 @@ export function ToolCard({ tool, thinking }: ToolCardProps) {
         )}
 
         {hasResult && !hasMcpApp && !isMcp && (
-          <div className="tool-card-body-inner">
-            {tool.result.split('\n').map((line, i) => (
-              <span key={i} data-collider="tool-result-line">
-                {line === '' ? <br /> : <Markdown className="text-xs">{line}</Markdown>}
-              </span>
-            ))}
+          <div className="tool-card-body-inner" data-collider="tool-result-line">
+            <Markdown className="text-xs">{tool.result}</Markdown>
           </div>
         )}
 
@@ -363,7 +359,7 @@ export function ToolCard({ tool, thinking }: ToolCardProps) {
 
         {isMcp && !hasRichList && hasResult && (
           <div className="mcp-raw-block" data-collider="tool-result-line">
-            {tool.result}
+            <Markdown className="text-xs">{tool.result}</Markdown>
           </div>
         )}
       </div>

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -400,17 +400,11 @@
 
   .tool-card-body-inner {
     padding: 0 14px 12px;
-    font-family: 'Geist Mono', 'JetBrains Mono', monospace;
-    font-size: 11px;
-    line-height: 1.5;
-    color: var(--color-text-muted);
     border-top: 1px solid var(--color-border);
     padding-top: 10px;
     margin-top: 2px;
-    max-height: 200px;
+    max-height: 400px;
     overflow-y: auto;
-    white-space: pre-wrap;
-    word-break: break-all;
   }
 
   /* ── MCP Badge ── */
@@ -501,14 +495,8 @@
   .mcp-raw-block {
     padding: 12px 14px;
     border-top: 1px solid var(--color-border);
-    font-family: 'Geist Mono', 'JetBrains Mono', monospace;
-    font-size: 11px;
-    line-height: 1.55;
-    color: var(--color-text-muted);
     max-height: 280px;
     overflow-y: auto;
-    white-space: pre-wrap;
-    word-break: break-all;
     background: var(--color-bg);
   }
 

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -399,11 +399,10 @@
   }
 
   .tool-card-body-inner {
-    padding: 0 14px 12px;
-    border-top: 1px solid var(--color-border);
-    padding-top: 10px;
-    margin-top: 2px;
+    padding: 2px 14px 6px;
+    margin-top: 0;
     max-height: 400px;
+    background: var(--color-bg);
     overflow-y: auto;
   }
 
@@ -426,7 +425,6 @@
   .mcp-rich-list {
     display: flex;
     flex-direction: column;
-    border-top: 1px solid var(--color-border);
   }
   .mcp-rich-item {
     padding: 12px 14px;
@@ -493,8 +491,7 @@
 
   /* ── MCP Raw Output ── */
   .mcp-raw-block {
-    padding: 12px 14px;
-    border-top: 1px solid var(--color-border);
+    padding: 2px 14px 6px;
     max-height: 280px;
     overflow-y: auto;
     background: var(--color-bg);
@@ -539,6 +536,30 @@
     background-color: var(--color-accent);
   }
 }
+
+/* ── Unlayered: Markdown <pre> base + ToolCard scoped override ──
+   Unlayered CSS beats ALL @layer rules, including @layer utilities where
+   Tailwind's p-3 (12px) and my-1 (4px) live. @layer components rules could
+   never override @layer utilities regardless of specificity — that's why the
+   previous scoped override inside @layer components never worked.
+   Moving these rules to unlayered CSS is the fix. */
+.md-pre-base {
+  border-radius: 8px;
+  background-color: var(--color-bg);
+  border: 1px solid var(--color-border);
+  color: var(--color-text);
+}
+
+/* ToolCard-scoped override: unlayered (beats @layer utilities) + higher
+   specificity than .md-pre-base (two classes vs one). Overrides padding
+   (p-3 → 6px 10px), margin (my-1 → 0), border (→ none), border-radius (→ 4px). */
+.tool-card-body-inner .md-pre-base {
+  padding: 6px 10px;
+  margin: 0;
+  border: none;
+  border-radius: 4px;
+}
+
 
 @media (max-width: 767px) {
   .resize-handle {


### PR DESCRIPTION
## Summary

   v0.2.6 — a focused polish release improving file upload handling, fixing WebUI
   rendering bugs, and streamlining the OpenSpec workflow.

   ## Changes

   ### 📎 File Upload & Attachment Improvements

   - **Split drag-drop `fileRefs` by type** — non-images are now passed as path references
   instead of being incorrectly treated as image payloads (`3e55c14`)
   - **Pre-drain file tracker before Editor clears** — fixes a TUI race where file
   references were lost on submit (`f6d5498`)
   - **Vision: pass compressed cached images** — compressed cached images are now
   correctly forwarded to both the vision model and OCR pipeline (`9924f26`)
   - **File upload cache management & size limits** — adds proper cache lifecycle and
   enforces upload size boundaries (`44590aa`)
   - **Base64 encoding for non-image uploads** — Web UI now encodes non-image files as
   base64, matching the expected wire format (`8f64ba5`)

   ### 🖥️ WebUI Fixes

   - **Real per-message `createdAt` timestamps** — replaces a hardcoded placeholder with
   actual message timestamps from the backend (`e2a5bad`)
   - **Remove ghost progress container** — fixes a blank gap in `ToolCard` caused by an
   empty progress element that was never cleaned up (`2fed401`)
   - **Tool result rendering** — strips conflicting CSS from MCP tool output and uses
   Markdown rendering for raw blocks, preventing style bleed (`7a20621`)

   ### 🔧 OpenSpec Workflow

   - **Explore → prototypes rule** — the explore command now auto-generates HTML
   prototypes from design options; UI detection keywords normalized to English (`8b60b10`)
   - **Simplify `/opsx:archive` flow** — streamlined the archive command UX; pin
   `openspec` to `devDependencies` (`1fa0106`)

   ### 🧹 Housekeeping

   - Archive 4 completed change proposals with consolidated spec docs (`4489b24`)